### PR TITLE
Add @urban-ui/content layout component

### DIFF
--- a/apps/docs/src/app/text/fontFamilies.tsx
+++ b/apps/docs/src/app/text/fontFamilies.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex'
 import { Flex } from '@urban-ui/flex'
 import { Text } from '@urban-ui/text'
 import { tone } from '@urban-ui/theme/colors.stylex'
-import { sizes, space } from '@urban-ui/theme/layout.stylex'
+import { content, space } from '@urban-ui/theme/layout.stylex'
 import { fontSizes, fonts } from '@urban-ui/theme/type.stylex'
 
 const styles = stylex.create({
@@ -19,7 +19,7 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   textContent: {
-    maxWidth: sizes.contentWide,
+    maxWidth: content.wide,
   },
 })
 

--- a/apps/docs/src/app/text/textLeading.tsx
+++ b/apps/docs/src/app/text/textLeading.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex'
 import { Flex } from '@urban-ui/flex'
 import { Text } from '@urban-ui/text'
 import { tone } from '@urban-ui/theme/colors.stylex'
-import { sizes, space } from '@urban-ui/theme/layout.stylex'
+import { content, space } from '@urban-ui/theme/layout.stylex'
 import { fontSizes } from '@urban-ui/theme/type.stylex'
 
 const styles = stylex.create({
@@ -19,7 +19,7 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   textContent: {
-    maxWidth: sizes.contentWide,
+    maxWidth: content.wide,
   },
 })
 

--- a/apps/tanstack/package.json
+++ b/apps/tanstack/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-router": "^1.120.6",
     "@urban-ui/button": "workspace:*",
     "@urban-ui/center": "workspace:*",
+    "@urban-ui/content": "workspace:*",
     "@urban-ui/flex": "workspace:*",
     "@urban-ui/icon": "workspace:*",
     "@urban-ui/link": "workspace:*",

--- a/apps/tanstack/src/routes/patterns/layout/content/route.tsx
+++ b/apps/tanstack/src/routes/patterns/layout/content/route.tsx
@@ -1,0 +1,135 @@
+import * as stylex from '@stylexjs/stylex'
+import { createFileRoute } from '@tanstack/react-router'
+import { Content } from '@urban-ui/content'
+import { Flex } from '@urban-ui/flex'
+import { Text } from '@urban-ui/text'
+import { radii } from '@urban-ui/theme/borders.stylex'
+import { base, tone } from '@urban-ui/theme/colors.stylex'
+import { space } from '@urban-ui/theme/layout.stylex'
+
+export const Route = createFileRoute('/patterns/layout/content/')({
+  component: ContentPatterns,
+})
+
+const styles = stylex.create({
+  page: {
+    padding: space[600],
+  },
+  container: {
+    padding: space[300],
+    backgroundColor: base.white,
+    color: tone.fgHi,
+    borderRadius: radii.md,
+  },
+  demoContainer: {
+    backgroundColor: tone.surfaceMuted,
+    borderRadius: radii.md,
+    padding: space[200],
+  },
+  contentBlock: {
+    backgroundColor: tone.solid,
+    color: base.white,
+    borderRadius: radii.sm,
+    padding: space[200],
+  },
+  fullWidth: {
+    width: '100%',
+  },
+})
+
+function ContentPatterns() {
+  return (
+    <Flex direction="column" gap="400" style={styles.page}>
+      <Text size="xxl" weight="bold">
+        Content Patterns
+      </Text>
+
+      {/* Width Constraints */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Width Constraints
+        </Text>
+        <Text size="sm" color="lo">
+          Content can constrain its max-width to standard content sizes.
+        </Text>
+        <Flex direction="v" gap="200" style={styles.demoContainer}>
+          <Content width="wide" style={styles.contentBlock}>
+            <Text>Wide content (48rem max-width)</Text>
+          </Content>
+          <Content width="narrow" style={styles.contentBlock}>
+            <Text>Narrow content (32rem max-width)</Text>
+          </Content>
+        </Flex>
+      </Flex>
+
+      {/* Edge Padding */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Edge Padding
+        </Text>
+        <Text size="sm" color="lo">
+          Use edgeBlock and edgeInline to add padding around content.
+        </Text>
+        <Flex direction="v" gap="200" style={styles.demoContainer}>
+          <Content edgeBlock="md" edgeInline="lg" style={styles.contentBlock}>
+            <Text>
+              Content with medium block padding (16px) and large inline padding
+              (24px)
+            </Text>
+          </Content>
+        </Flex>
+      </Flex>
+
+      {/* Combined Usage */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Combined Usage
+        </Text>
+        <Text size="sm" color="lo">
+          Combine width constraints with edge padding for common layout
+          patterns.
+        </Text>
+        <Flex direction="v" gap="200" style={styles.demoContainer}>
+          <Content
+            width="narrow"
+            edgeBlock="lg"
+            edgeInline="md"
+            style={styles.contentBlock}
+          >
+            <Text>
+              Narrow content with large block padding and medium inline padding.
+              This is useful for article-style layouts where you want
+              comfortable reading widths.
+            </Text>
+          </Content>
+        </Flex>
+      </Flex>
+
+      {/* Page Layout Example */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Page Layout Example
+        </Text>
+        <Text size="sm" color="lo">
+          A typical page layout using Content for main content area.
+        </Text>
+        <Flex direction="v" style={[styles.demoContainer, styles.fullWidth]}>
+          <Content
+            width="wide"
+            edgeBlock="xl"
+            edgeInline="md"
+            style={styles.contentBlock}
+          >
+            <Flex direction="v" gap="200">
+              <Text weight="semibold">Page Title</Text>
+              <Text size="sm">
+                This demonstrates how Content can be used to create a centered,
+                width-constrained page layout with comfortable edge spacing.
+              </Text>
+            </Flex>
+          </Content>
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,7 @@
         "@tanstack/react-router": "^1.120.6",
         "@urban-ui/button": "workspace:*",
         "@urban-ui/center": "workspace:*",
+        "@urban-ui/content": "workspace:*",
         "@urban-ui/flex": "workspace:*",
         "@urban-ui/icon": "workspace:*",
         "@urban-ui/link": "workspace:*",
@@ -357,6 +358,30 @@
       "version": "0.0.1",
       "dependencies": {
         "@urban-ui/flex": "workspace:*",
+      },
+      "devDependencies": {
+        "@rsbuild/plugin-react": "1.4.2",
+        "@rslib/core": "0.19.2",
+        "@stylexjs/stylex": "0.17.5",
+        "@types/node": "^24",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@urban-ui/tsconfig": "workspace:*",
+        "del-cli": "^6.0.0",
+        "react": "19.2.3",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "@stylexjs/stylex": "0.17.5",
+        "react": "19.2.3",
+      },
+    },
+    "packages/layout/content": {
+      "name": "@urban-ui/content",
+      "version": "0.0.1",
+      "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
+        "@urban-ui/theme": "workspace:*",
       },
       "devDependencies": {
         "@rsbuild/plugin-react": "1.4.2",
@@ -1571,6 +1596,8 @@
     "@urban-ui/button": ["@urban-ui/button@workspace:packages/action/button"],
 
     "@urban-ui/center": ["@urban-ui/center@workspace:packages/layout/center"],
+
+    "@urban-ui/content": ["@urban-ui/content@workspace:packages/layout/content"],
 
     "@urban-ui/flex": ["@urban-ui/flex@workspace:packages/layout/flex"],
 

--- a/docs/application-patterns.md
+++ b/docs/application-patterns.md
@@ -64,7 +64,7 @@ const styles = stylex.create({
 
 ```tsx
 import { Flex } from '@urban-ui/flex'
-import { sizes, space } from '@urban-ui/theme/layout.stylex'
+import { content, sizes, space } from '@urban-ui/theme/layout.stylex'
 
 const styles = stylex.create({
   page: {
@@ -73,7 +73,7 @@ const styles = stylex.create({
     paddingInline: space['200'],
   },
   content: {
-    maxWidth: sizes.contentWide,
+    maxWidth: content.wide,
     marginInline: 'auto',
     width: sizes.full,
   },

--- a/packages/core/theme/src/tokens/layout.stylex.ts
+++ b/packages/core/theme/src/tokens/layout.stylex.ts
@@ -97,8 +97,31 @@ export const sizes = defineVars({
   min: 'min-content',
   max: 'max-content',
   fit: 'fit-content',
-  contentWide: '48rem',
-  contentNarrow: '32rem',
+})
+
+/**
+ * @tokens content
+ * @css maxWidth
+ * @description Content width constraints for layout containers
+ */
+export const content = defineVars({
+  wide: '48rem',
+  narrow: '32rem',
+})
+
+/**
+ * @tokens edge
+ * @css paddingBlock, paddingInline
+ * @description Edge spacing for distance from inner components to container edge
+ */
+export const edge = defineVars({
+  none: '0px',
+  xxs: '2px',
+  xs: '4px',
+  sm: '8px',
+  md: '16px',
+  lg: '24px',
+  xl: '32px',
 })
 
 /**

--- a/packages/layout/content/package.json
+++ b/packages/layout/content/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@urban-ui/content",
+  "version": "0.0.1",
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "lint": "biome lint src",
+    "format": "biome format src --write",
+    "typecheck": "tsc",
+    "clean": "del dist",
+    "dev": "rslib build --watch",
+    "build": "rslib build"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
+    "@urban-ui/theme": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "19.2.3",
+    "@stylexjs/stylex": "0.17.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@rsbuild/plugin-react": "1.4.2",
+    "@rslib/core": "0.19.2",
+    "@stylexjs/stylex": "0.17.5",
+    "@urban-ui/tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "react": "19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/layout/content/rslib.config.ts
+++ b/packages/layout/content/rslib.config.ts
@@ -1,0 +1,28 @@
+import { pluginReact } from '@rsbuild/plugin-react'
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  lib: [
+    {
+      format: 'esm',
+      syntax: ['node 18'],
+      dts: true,
+      bundle: false,
+    },
+  ],
+  output: {
+    target: 'web',
+  },
+  source: {
+    entry: {
+      main: [
+        './src/**',
+        '!./src/**/*.test.ts',
+        '!./src/**/*.stories.tsx',
+        '!./src/**/*.spec.md',
+        '!./src/**/*.example.tsx',
+      ],
+    },
+  },
+})

--- a/packages/layout/content/src/content.tsx
+++ b/packages/layout/content/src/content.tsx
@@ -1,0 +1,122 @@
+import { Slot } from '@radix-ui/react-slot'
+import * as stylex from '@stylexjs/stylex'
+import type { StyleXStyles, Theme, VarGroup } from '@stylexjs/stylex'
+import { content, edge } from '@urban-ui/theme/layout.stylex'
+import { forwardRef } from 'react'
+
+const styles = stylex.create({
+  base: {
+    display: 'block',
+  },
+
+  // Width
+  wide: { maxWidth: content.wide },
+  narrow: { maxWidth: content.narrow },
+
+  // Edge Block (paddingBlock)
+  edgeBlockNone: { paddingBlock: edge.none },
+  edgeBlockXxs: { paddingBlock: edge.xxs },
+  edgeBlockXs: { paddingBlock: edge.xs },
+  edgeBlockSm: { paddingBlock: edge.sm },
+  edgeBlockMd: { paddingBlock: edge.md },
+  edgeBlockLg: { paddingBlock: edge.lg },
+  edgeBlockXl: { paddingBlock: edge.xl },
+
+  // Edge Inline (paddingInline)
+  edgeInlineNone: { paddingInline: edge.none },
+  edgeInlineXxs: { paddingInline: edge.xxs },
+  edgeInlineXs: { paddingInline: edge.xs },
+  edgeInlineSm: { paddingInline: edge.sm },
+  edgeInlineMd: { paddingInline: edge.md },
+  edgeInlineLg: { paddingInline: edge.lg },
+  edgeInlineXl: { paddingInline: edge.xl },
+})
+
+const widthStyle = {
+  wide: styles.wide,
+  narrow: styles.narrow,
+}
+
+const edgeBlockStyle = {
+  none: styles.edgeBlockNone,
+  xxs: styles.edgeBlockXxs,
+  xs: styles.edgeBlockXs,
+  sm: styles.edgeBlockSm,
+  md: styles.edgeBlockMd,
+  lg: styles.edgeBlockLg,
+  xl: styles.edgeBlockXl,
+}
+
+const edgeInlineStyle = {
+  none: styles.edgeInlineNone,
+  xxs: styles.edgeInlineXxs,
+  xs: styles.edgeInlineXs,
+  sm: styles.edgeInlineSm,
+  md: styles.edgeInlineMd,
+  lg: styles.edgeInlineLg,
+  xl: styles.edgeInlineXl,
+}
+
+// @ts-expect-error typing for var group prefers a known object for its keys, we want a generic object and let the compiler work it out
+type GenericTheme = Theme<VarGroup<unknown>> | Array<Theme<VarGroup<unknown>>>
+
+export interface ContentProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style'>,
+    React.PropsWithChildren {
+  /**
+   * Maximum width constraint for the content
+   */
+  width?: 'wide' | 'narrow'
+
+  /**
+   * Padding on the block axis (top and bottom)
+   */
+  edgeBlock?: 'none' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+  /**
+   * Padding on the inline axis (left and right)
+   */
+  edgeInline?: 'none' | 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+  /**
+   * StyleX style overrides
+   */
+  style?: StyleXStyles | GenericTheme | Array<StyleXStyles | GenericTheme>
+
+  /**
+   * Whether to use the Slot component instead of a div
+   */
+  asChild?: boolean
+}
+
+export const Content = forwardRef<HTMLDivElement, ContentProps>((props, ref) => {
+  const {
+    width,
+    edgeBlock,
+    edgeInline,
+    style = [],
+    className,
+    children,
+    asChild = false,
+    ...rest
+  } = props
+
+  const Element = asChild ? Slot : 'div'
+
+  return (
+    <Element
+      ref={ref}
+      className={className}
+      {...rest}
+      {...stylex.props(
+        styles.base,
+        width != null && widthStyle[width],
+        edgeBlock != null && edgeBlockStyle[edgeBlock],
+        edgeInline != null && edgeInlineStyle[edgeInline],
+        style,
+      )}
+    >
+      {children}
+    </Element>
+  )
+})

--- a/packages/layout/content/src/index.ts
+++ b/packages/layout/content/src/index.ts
@@ -1,0 +1,1 @@
+export { Content, type ContentProps } from './content'

--- a/packages/layout/content/tsconfig.json
+++ b/packages/layout/content/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@urban-ui/tsconfig/react-library.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
## Summary
Adds a new Content layout component for handling component content layout, along with new token scales for content width and edge spacing.

## Changes
- Add new `content` token scale with `wide` (48rem) and `narrow` (32rem) values (moved from sizes scale)
- Add new `edge` token scale with values: none, xxs, xs, sm, md, lg, xl for edge spacing
- Create `@urban-ui/content` package under packages/layout/content
- Content component supports:
  - `width` prop: 'wide' | 'narrow' for max-width constraints
  - `edgeBlock` prop: padding on block axis (top/bottom)
  - `edgeInline` prop: padding on inline axis (left/right)
  - `style` prop: StyleX style overrides
  - `asChild` prop: Slot component pattern
- Update existing usages of `sizes.contentWide` to use new `content.wide` token
- Add example page in tanstack app at /patterns/layout/content/

## Testing
- Build passes: `bun run --filter=@urban-ui/content build`
- Typecheck passes: `bun run --filter=@urban-ui/content typecheck`
- View examples at `/patterns/layout/content/` in the tanstack app