### PR TITLE
Add @urban-ui/form package

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "urban-ui": {
       "command": "bun",
-      "args": ["run", "packages/zeus/mcp/src/index.ts"]
+      "args": ["run", "packages/zeus/mcp/dist/index.js"]
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -314,6 +314,7 @@
       "name": "@urban-ui/form",
       "version": "0.1.0",
       "dependencies": {
+        "@urban-ui/text": "workspace:*",
         "@urban-ui/theme": "workspace:*",
         "react-aria-components": "1.14.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -310,6 +310,40 @@
         "react": "19.2.3",
       },
     },
+    "packages/interaction/form": {
+      "name": "@urban-ui/form",
+      "version": "0.1.0",
+      "dependencies": {
+        "@urban-ui/theme": "workspace:*",
+        "react-aria-components": "1.14.0",
+      },
+      "devDependencies": {
+        "@happy-dom/jest-environment": "^20.3.3",
+        "@jest/globals": "^30.2.0",
+        "@rsbuild/plugin-react": "1.4.2",
+        "@rslib/core": "0.19.2",
+        "@stylexswc/jest": "0.14.2",
+        "@swc/jest": "^0.2.39",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@urban-ui/tsconfig": "workspace:*",
+        "del-cli": "^6.0.0",
+        "expect-type": "^1.2.1",
+        "jest": "^30.2.0",
+        "jest-chain-transform": "^0.0.8",
+        "react": "19.2.3",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "@stylexjs/stylex": "0.17.5",
+        "react": "19.2.3",
+      },
+    },
     "packages/internal/container": {
       "name": "@internal/container",
       "version": "0.1.1",
@@ -1600,6 +1634,8 @@
     "@urban-ui/content": ["@urban-ui/content@workspace:packages/layout/content"],
 
     "@urban-ui/flex": ["@urban-ui/flex@workspace:packages/layout/flex"],
+
+    "@urban-ui/form": ["@urban-ui/form@workspace:packages/interaction/form"],
 
     "@urban-ui/icon": ["@urban-ui/icon@workspace:packages/display/icon"],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "packages/feedback/*",
     "packages/action/*",
     "packages/navigation/*",
-    "packages/display/*"
+    "packages/display/*",
+    "packages/interaction/*"
   ],
   "repository": {
     "type": "git",

--- a/packages/interaction/form/jest.config.js
+++ b/packages/interaction/form/jest.config.js
@@ -1,0 +1,66 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url))
+
+/** @type {import('jest').Config} */
+export default {
+  setupFilesAfterEnv: [path.join(rootDir, 'jest.setup.js')],
+  testEnvironment: '@happy-dom/jest-environment',
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx|mjs|cjs|html)$': [
+      'jest-chain-transform',
+      {
+        transformers: [
+          [
+            '@stylexswc/jest',
+            {
+              rsOptions: {
+                aliases: {
+                  '@/*': [path.join(rootDir, '*')],
+                },
+                unstable_moduleResolution: {
+                  type: 'commonJS',
+                },
+              },
+            },
+          ],
+          [
+            '@swc/jest',
+            {
+              $schema: 'https://json.schemastore.org/swcrc',
+              jsc: {
+                parser: {
+                  syntax: 'typescript',
+                  tsx: true,
+                  dynamicImport: true,
+                  decorators: true,
+                  dts: true,
+                },
+                transform: {
+                  react: {
+                    useBuiltins: true,
+                    runtime: 'automatic',
+                  },
+                },
+                target: 'esnext',
+                loose: false,
+                externalHelpers: false,
+                keepClassNames: true,
+                baseUrl: './',
+
+                paths: {
+                  '@/*': ['./*'],
+                },
+              },
+              module: {
+                type: 'es6',
+              },
+              minify: false,
+            },
+          ],
+        ],
+      },
+    ],
+  },
+}

--- a/packages/interaction/form/jest.setup.js
+++ b/packages/interaction/form/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/interaction/form/package.json
+++ b/packages/interaction/form/package.json
@@ -20,7 +20,7 @@
     "clean": "del dist",
     "dev": "rslib build --watch",
     "build": "rslib build",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/interaction/form/package.json
+++ b/packages/interaction/form/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@urban-ui/form",
+  "version": "0.1.0",
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "lint": "biome lint src",
+    "format": "biome format src --write",
+    "typecheck": "tsc",
+    "clean": "del dist",
+    "dev": "rslib build --watch",
+    "build": "rslib build",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@urban-ui/theme": "workspace:*",
+    "react-aria-components": "1.14.0"
+  },
+  "peerDependencies": {
+    "react": "19.2.3",
+    "@stylexjs/stylex": "0.17.5"
+  },
+  "devDependencies": {
+    "@happy-dom/jest-environment": "^20.3.3",
+    "@jest/globals": "^30.2.0",
+    "@stylexswc/jest": "0.14.2",
+    "@swc/jest": "^0.2.39",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@rsbuild/plugin-react": "1.4.2",
+    "@rslib/core": "0.19.2",
+    "@urban-ui/tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "expect-type": "^1.2.1",
+    "jest": "^30.2.0",
+    "jest-chain-transform": "^0.0.8",
+    "react": "19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/interaction/form/package.json
+++ b/packages/interaction/form/package.json
@@ -24,6 +24,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@urban-ui/text": "workspace:*",
     "@urban-ui/theme": "workspace:*",
     "react-aria-components": "1.14.0"
   },

--- a/packages/interaction/form/rslib.config.ts
+++ b/packages/interaction/form/rslib.config.ts
@@ -1,0 +1,29 @@
+import { pluginReact } from '@rsbuild/plugin-react'
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  lib: [
+    {
+      format: 'esm',
+      syntax: ['node 18'],
+      dts: true,
+      bundle: false,
+    },
+  ],
+  output: {
+    target: 'web',
+  },
+  source: {
+    entry: {
+      main: [
+        './src/**',
+        '!./src/**/*.test.ts',
+        '!./src/**/*.test.tsx',
+        '!./src/**/*.stories.tsx',
+        '!./src/**/*.spec.md',
+        '!./src/**/*.example.tsx',
+      ],
+    },
+  },
+})

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -2,17 +2,14 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
+import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
-import { fontSizes, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { TextProps as AriaTextProps } from 'react-aria-components'
 import { Text as AriaText } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    fontSize: fontSizes.sm,
-    lineHeight: lineHeights.sm,
-    color: 'var(--text-muted, #6b7280)',
     marginBlockStart: space[100],
   },
 })
@@ -30,13 +27,11 @@ export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> 
  */
 export function Description({ children, style, ...props }: DescriptionProps) {
   return (
-    <AriaText
-      {...props}
-      slot="description"
-      {...stylex.props([styles.base, style])}
-    >
-      {children}
-    </AriaText>
+    <Text asChild size="sm" color="lo" style={[styles.base, style]}>
+      <AriaText {...props} slot="description">
+        {children}
+      </AriaText>
+    </Text>
   )
 }
 Description.displayName = '@urban-ui/form/description'

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -4,6 +4,8 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
+import type { TextProps as AriaTextProps } from 'react-aria-components'
+import { Text as AriaText } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -12,8 +14,7 @@ const styles = stylex.create({
   },
 })
 
-export interface DescriptionProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'style'> {
+export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> {
   /**
    * Additional styles to apply
    */
@@ -21,13 +22,15 @@ export interface DescriptionProps
 }
 
 /**
- * Description component for form fields.
+ * Description component built on react-aria-components.
  * Provides accessible description text for form fields.
  */
 export function Description({ children, style, ...props }: DescriptionProps) {
   return (
     <Text asChild size="sm" color="lo" style={[styles.base, style]}>
-      <span {...props}>{children}</span>
+      <AriaText {...props} slot="description">
+        {children}
+      </AriaText>
     </Text>
   )
 }

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { StyleXStyles } from '@stylexjs/stylex'
+import * as stylex from '@stylexjs/stylex'
+import { fontSizes, lineHeights, space } from '@urban-ui/theme'
+import type { TextProps as AriaTextProps } from 'react-aria-components'
+import { Text as AriaText } from 'react-aria-components'
+
+const styles = stylex.create({
+  base: {
+    display: 'block',
+    fontSize: fontSizes.sm,
+    lineHeight: lineHeights.normal,
+    color: 'var(--text-muted, #6b7280)',
+    marginBlockStart: space[100],
+  },
+})
+
+export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> {
+  /**
+   * Additional styles to apply
+   */
+  style?: StyleXStyles
+}
+
+/**
+ * Description component built on react-aria-components.
+ * Provides accessible description text for form fields.
+ */
+export function Description({ children, style, ...props }: DescriptionProps) {
+  return (
+    <AriaText
+      {...props}
+      slot="description"
+      {...stylex.props([styles.base, style])}
+    >
+      {children}
+    </AriaText>
+  )
+}
+Description.displayName = '@urban-ui/form/description'

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -2,7 +2,8 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
-import { fontSizes, lineHeights, space } from '@urban-ui/theme'
+import { space } from '@urban-ui/theme/layout.stylex'
+import { fontSizes, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { TextProps as AriaTextProps } from 'react-aria-components'
 import { Text as AriaText } from 'react-aria-components'
 
@@ -10,7 +11,7 @@ const styles = stylex.create({
   base: {
     display: 'block',
     fontSize: fontSizes.sm,
-    lineHeight: lineHeights.normal,
+    lineHeight: lineHeights.sm,
     color: 'var(--text-muted, #6b7280)',
     marginBlockStart: space[100],
   },

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -4,8 +4,6 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
-import type { TextProps as AriaTextProps } from 'react-aria-components'
-import { Text as AriaText } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -14,7 +12,8 @@ const styles = stylex.create({
   },
 })
 
-export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> {
+export interface DescriptionProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'style'> {
   /**
    * Additional styles to apply
    */
@@ -22,15 +21,13 @@ export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> 
 }
 
 /**
- * Description component built on react-aria-components.
+ * Description component for form fields.
  * Provides accessible description text for form fields.
  */
 export function Description({ children, style, ...props }: DescriptionProps) {
   return (
     <Text asChild size="sm" color="lo" style={[styles.base, style]}>
-      <AriaText {...props} slot="description">
-        {children}
-      </AriaText>
+      <span {...props}>{children}</span>
     </Text>
   )
 }

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -5,8 +5,6 @@ import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { themes } from '@urban-ui/theme'
 import { space } from '@urban-ui/theme/layout.stylex'
-import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
-import { FieldError as AriaFieldError } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -15,7 +13,8 @@ const styles = stylex.create({
   },
 })
 
-export interface FieldErrorProps extends Omit<AriaFieldErrorProps, 'style'> {
+export interface FieldErrorProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'style'> {
   /**
    * Additional styles to apply
    */
@@ -23,7 +22,7 @@ export interface FieldErrorProps extends Omit<AriaFieldErrorProps, 'style'> {
 }
 
 /**
- * FieldError component built on react-aria-components.
+ * FieldError component for form fields.
  * Displays validation error messages for form fields.
  */
 export function FieldError({ children, style, ...props }: FieldErrorProps) {
@@ -34,7 +33,7 @@ export function FieldError({ children, style, ...props }: FieldErrorProps) {
       color="hi"
       style={[styles.base, themes.critical, style]}
     >
-      <AriaFieldError {...props}>{children}</AriaFieldError>
+      <span {...props}>{children}</span>
     </Text>
   )
 }

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -5,6 +5,8 @@ import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { themes } from '@urban-ui/theme'
 import { space } from '@urban-ui/theme/layout.stylex'
+import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
+import { FieldError as AriaFieldError } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -13,8 +15,7 @@ const styles = stylex.create({
   },
 })
 
-export interface FieldErrorProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'style'> {
+export interface FieldErrorProps extends Omit<AriaFieldErrorProps, 'style'> {
   /**
    * Additional styles to apply
    */
@@ -22,7 +23,7 @@ export interface FieldErrorProps
 }
 
 /**
- * FieldError component for form fields.
+ * FieldError component built on react-aria-components.
  * Displays validation error messages for form fields.
  */
 export function FieldError({ children, style, ...props }: FieldErrorProps) {
@@ -33,7 +34,7 @@ export function FieldError({ children, style, ...props }: FieldErrorProps) {
       color="hi"
       style={[styles.base, themes.critical, style]}
     >
-      <span {...props}>{children}</span>
+      <AriaFieldError {...props}>{children}</AriaFieldError>
     </Text>
   )
 }

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { StyleXStyles } from '@stylexjs/stylex'
+import * as stylex from '@stylexjs/stylex'
+import { fontSizes, lineHeights, space } from '@urban-ui/theme'
+import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
+import { FieldError as AriaFieldError } from 'react-aria-components'
+
+const styles = stylex.create({
+  base: {
+    display: 'block',
+    fontSize: fontSizes.sm,
+    lineHeight: lineHeights.normal,
+    color: 'var(--text-critical, #dc2626)',
+    marginBlockStart: space[100],
+  },
+})
+
+export interface FieldErrorProps extends Omit<AriaFieldErrorProps, 'style'> {
+  /**
+   * Additional styles to apply
+   */
+  style?: StyleXStyles
+}
+
+/**
+ * FieldError component built on react-aria-components.
+ * Displays validation error messages for form fields.
+ */
+export function FieldError({ children, style, ...props }: FieldErrorProps) {
+  return (
+    <AriaFieldError {...props} {...stylex.props([styles.base, style])}>
+      {children}
+    </AriaFieldError>
+  )
+}
+FieldError.displayName = '@urban-ui/form/field-error'

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -2,7 +2,8 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
-import { fontSizes, lineHeights, space } from '@urban-ui/theme'
+import { space } from '@urban-ui/theme/layout.stylex'
+import { fontSizes, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
 import { FieldError as AriaFieldError } from 'react-aria-components'
 
@@ -10,7 +11,7 @@ const styles = stylex.create({
   base: {
     display: 'block',
     fontSize: fontSizes.sm,
-    lineHeight: lineHeights.normal,
+    lineHeight: lineHeights.sm,
     color: 'var(--text-critical, #dc2626)',
     marginBlockStart: space[100],
   },

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -2,17 +2,15 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
+import { Text } from '@urban-ui/text'
+import { themes } from '@urban-ui/theme'
 import { space } from '@urban-ui/theme/layout.stylex'
-import { fontSizes, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
 import { FieldError as AriaFieldError } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    fontSize: fontSizes.sm,
-    lineHeight: lineHeights.sm,
-    color: 'var(--text-critical, #dc2626)',
     marginBlockStart: space[100],
   },
 })
@@ -30,9 +28,14 @@ export interface FieldErrorProps extends Omit<AriaFieldErrorProps, 'style'> {
  */
 export function FieldError({ children, style, ...props }: FieldErrorProps) {
   return (
-    <AriaFieldError {...props} {...stylex.props([styles.base, style])}>
-      {children}
-    </AriaFieldError>
+    <Text
+      asChild
+      size="sm"
+      color="hi"
+      style={[styles.base, themes.critical, style]}
+    >
+      <AriaFieldError {...props}>{children}</AriaFieldError>
+    </Text>
   )
 }
 FieldError.displayName = '@urban-ui/form/field-error'

--- a/packages/interaction/form/src/form.tsx
+++ b/packages/interaction/form/src/form.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import type { StyleXStyles } from '@stylexjs/stylex'
+import * as stylex from '@stylexjs/stylex'
+import type { FormProps as AriaFormProps } from 'react-aria-components'
+import { Form as AriaForm } from 'react-aria-components'
+
+const styles = stylex.create({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+})
+
+export interface FormProps extends Omit<AriaFormProps, 'style'> {
+  /**
+   * Additional styles to apply
+   */
+  style?: StyleXStyles
+}
+
+/**
+ * Form component built on react-aria-components.
+ * Provides a form wrapper with validation support.
+ */
+export function Form({ children, style, ...props }: FormProps) {
+  return (
+    <AriaForm {...props} {...stylex.props([styles.base, style])}>
+      {children}
+    </AriaForm>
+  )
+}
+Form.displayName = '@urban-ui/form'

--- a/packages/interaction/form/src/index.ts
+++ b/packages/interaction/form/src/index.ts
@@ -1,0 +1,4 @@
+export * from './form'
+export * from './label'
+export * from './description'
+export * from './field-error'

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { StyleXStyles } from '@stylexjs/stylex'
+import * as stylex from '@stylexjs/stylex'
+import { fontSizes, fontWeights, lineHeights, space } from '@urban-ui/theme'
+import type { LabelProps as AriaLabelProps } from 'react-aria-components'
+import { Label as AriaLabel } from 'react-aria-components'
+
+const styles = stylex.create({
+  base: {
+    display: 'block',
+    fontSize: fontSizes.sm,
+    fontWeight: fontWeights.medium,
+    lineHeight: lineHeights.normal,
+    marginBlockEnd: space[100],
+  },
+})
+
+export interface LabelProps extends Omit<AriaLabelProps, 'style'> {
+  /**
+   * Additional styles to apply
+   */
+  style?: StyleXStyles
+}
+
+/**
+ * Label component built on react-aria-components.
+ * Provides accessible labeling for form fields.
+ */
+export function Label({ children, style, ...props }: LabelProps) {
+  return (
+    <AriaLabel {...props} {...stylex.props([styles.base, style])}>
+      {children}
+    </AriaLabel>
+  )
+}
+Label.displayName = '@urban-ui/form/label'

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -4,6 +4,8 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
+import type { LabelProps as AriaLabelProps } from 'react-aria-components'
+import { Label as AriaLabel } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -12,8 +14,7 @@ const styles = stylex.create({
   },
 })
 
-export interface LabelProps
-  extends Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'style'> {
+export interface LabelProps extends Omit<AriaLabelProps, 'style'> {
   /**
    * Additional styles to apply
    */
@@ -21,13 +22,13 @@ export interface LabelProps
 }
 
 /**
- * Label component for form fields.
- * Provides accessible labeling using native label element.
+ * Label component built on react-aria-components.
+ * Provides accessible labeling for form fields.
  */
 export function Label({ children, style, ...props }: LabelProps) {
   return (
     <Text asChild size="sm" weight="medium" style={[styles.base, style]}>
-      <label {...props}>{children}</label>
+      <AriaLabel {...props}>{children}</AriaLabel>
     </Text>
   )
 }

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -2,17 +2,14 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
+import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
-import { fontSizes, fontWeights, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { LabelProps as AriaLabelProps } from 'react-aria-components'
 import { Label as AriaLabel } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    fontSize: fontSizes.sm,
-    fontWeight: fontWeights.medium,
-    lineHeight: lineHeights.sm,
     marginBlockEnd: space[100],
   },
 })
@@ -30,9 +27,9 @@ export interface LabelProps extends Omit<AriaLabelProps, 'style'> {
  */
 export function Label({ children, style, ...props }: LabelProps) {
   return (
-    <AriaLabel {...props} {...stylex.props([styles.base, style])}>
-      {children}
-    </AriaLabel>
+    <Text asChild size="sm" weight="medium" style={[styles.base, style]}>
+      <AriaLabel {...props}>{children}</AriaLabel>
+    </Text>
   )
 }
 Label.displayName = '@urban-ui/form/label'

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -4,8 +4,6 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { space } from '@urban-ui/theme/layout.stylex'
-import type { LabelProps as AriaLabelProps } from 'react-aria-components'
-import { Label as AriaLabel } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
@@ -14,7 +12,8 @@ const styles = stylex.create({
   },
 })
 
-export interface LabelProps extends Omit<AriaLabelProps, 'style'> {
+export interface LabelProps
+  extends Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'style'> {
   /**
    * Additional styles to apply
    */
@@ -22,13 +21,13 @@ export interface LabelProps extends Omit<AriaLabelProps, 'style'> {
 }
 
 /**
- * Label component built on react-aria-components.
- * Provides accessible labeling for form fields.
+ * Label component for form fields.
+ * Provides accessible labeling using native label element.
  */
 export function Label({ children, style, ...props }: LabelProps) {
   return (
     <Text asChild size="sm" weight="medium" style={[styles.base, style]}>
-      <AriaLabel {...props}>{children}</AriaLabel>
+      <label {...props}>{children}</label>
     </Text>
   )
 }

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -2,7 +2,8 @@
 
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
-import { fontSizes, fontWeights, lineHeights, space } from '@urban-ui/theme'
+import { space } from '@urban-ui/theme/layout.stylex'
+import { fontSizes, fontWeights, lineHeights } from '@urban-ui/theme/type.stylex'
 import type { LabelProps as AriaLabelProps } from 'react-aria-components'
 import { Label as AriaLabel } from 'react-aria-components'
 
@@ -11,7 +12,7 @@ const styles = stylex.create({
     display: 'block',
     fontSize: fontSizes.sm,
     fontWeight: fontWeights.medium,
-    lineHeight: lineHeights.normal,
+    lineHeight: lineHeights.sm,
     marginBlockEnd: space[100],
   },
 })

--- a/packages/interaction/form/tsconfig.json
+++ b/packages/interaction/form/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@urban-ui/tsconfig/client.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/interaction/form/tsconfig.json
+++ b/packages/interaction/form/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@urban-ui/tsconfig/client.json",
+  "extends": "@urban-ui/tsconfig/react-library.json",
   "compilerOptions": {
     "rootDir": "src",
     "types": ["jest", "@testing-library/jest-dom"]


### PR DESCRIPTION

## Summary
Adds new `@urban-ui/form` package with shared form field components for building accessible forms.

## Changes
- Add new `packages/interaction/form` package structure
- Add `Form` component wrapping react-aria-components Form
- Add `Label` component using `@urban-ui/text` with react-aria Label
- Add `Description` component using `@urban-ui/text` with `color="lo"` for muted text
- Add `FieldError` component using `@urban-ui/text` with critical theme
- Add `packages/interaction/*` to workspace configuration
- Export all components from barrel index

## Testing
Run `bun run build --filter=@urban-ui/form` to verify the package builds successfully.