### PR TITLE
Add TextField component

### DIFF
--- a/.changeset/fuzzy-icons-cross.md
+++ b/.changeset/fuzzy-icons-cross.md
@@ -6,3 +6,6 @@
 ---
 
 :rocket: Textfield
+:godmode: Update text scale to provide a smoother curve for max sizes from xxs to md
+:godmode: More consistent handling of input error states
+:godmode: Balance adjustments for form field elements

--- a/.changeset/fuzzy-icons-cross.md
+++ b/.changeset/fuzzy-icons-cross.md
@@ -1,0 +1,8 @@
+---
+"@urban-ui/textfield": minor
+"@urban-ui/input": minor
+"@urban-ui/form": minor
+"@urban-ui/theme": minor
+---
+
+:rocket: Textfield

--- a/apps/tanstack/CLAUDE.md
+++ b/apps/tanstack/CLAUDE.md
@@ -1,0 +1,21 @@
+# Tanstack Demo App
+
+Demo application for urban-ui components using TanStack Router.
+
+## Route Generation
+
+This app uses TanStack Router's file-based routing. The route tree is auto-generated.
+
+**Important:** After adding new routes, linting and typecheck will fail until the route tree is regenerated. Run:
+
+```bash
+bun run build
+```
+
+This generates `src/routeTree.gen.ts` with the updated routes. The dev server also regenerates routes on file changes.
+
+## Adding New Routes
+
+1. Create a new route file at `src/routes/patterns/<component>/route.tsx`
+2. Run `bun run build` to generate the route tree
+3. Typecheck will pass after regeneration

--- a/apps/tanstack/package.json
+++ b/apps/tanstack/package.json
@@ -24,6 +24,7 @@
     "@urban-ui/reset": "workspace:*",
     "@urban-ui/styles": "workspace:*",
     "@urban-ui/text": "workspace:*",
+    "@urban-ui/textfield": "workspace:*",
     "@urban-ui/theme": "workspace:*",
     "lucide-react": "0.562.0",
     "react": "19.2.3",

--- a/apps/tanstack/src/routes/patterns/text/route.tsx
+++ b/apps/tanstack/src/routes/patterns/text/route.tsx
@@ -32,6 +32,43 @@ const styles = stylex.create({
 function TextPatterns() {
   return (
     <Flex direction="column" gap="200" style={[styles.page]}>
+      {/* All Sizes */}
+      <Flex direction="v" gap="200" style={[styles.container]}>
+        <Text size="lg" weight="semibold">
+          All Sizes
+        </Text>
+        <Flex direction="v" gap="100">
+          <Text size="xxl">
+            <Text weight="semibold">xxl:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="xl">
+            <Text weight="semibold">xl:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="lg">
+            <Text weight="semibold">lg:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="md">
+            <Text weight="semibold">md:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="sm">
+            <Text weight="semibold">sm:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="xs">
+            <Text weight="semibold">xs:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+          <Text size="xxs">
+            <Text weight="semibold">xxs:</Text> The quick brown fox jumps over
+            the lazy dog.
+          </Text>
+        </Flex>
+      </Flex>
+
       <Flex direction="v" gap="200" style={[styles.container]}>
         <Text size="xxl">Page Title</Text>
         <Text size="lg">Section heading</Text>

--- a/apps/tanstack/src/routes/patterns/textfield/route.tsx
+++ b/apps/tanstack/src/routes/patterns/textfield/route.tsx
@@ -1,0 +1,188 @@
+import * as stylex from '@stylexjs/stylex'
+import { createFileRoute } from '@tanstack/react-router'
+import { Button } from '@urban-ui/button'
+import { Flex } from '@urban-ui/flex'
+import { Text } from '@urban-ui/text'
+import { TextField } from '@urban-ui/textfield'
+import { radii } from '@urban-ui/theme/borders.stylex'
+import { base, tone } from '@urban-ui/theme/colors.stylex'
+import { space } from '@urban-ui/theme/layout.stylex'
+
+export const Route = createFileRoute('/patterns/textfield/')({
+  component: TextFieldPatterns,
+})
+
+const styles = stylex.create({
+  page: {
+    padding: space[600],
+  },
+  container: {
+    padding: space[300],
+    backgroundColor: base.white,
+    color: tone.fgHi,
+    borderRadius: radii.md,
+  },
+  fieldContainer: {
+    maxWidth: '320px',
+  },
+})
+
+function TextFieldPatterns() {
+  return (
+    <Flex direction="column" gap="400" style={[styles.page]}>
+      <Text size="xxl" weight="bold">
+        TextField Patterns
+      </Text>
+
+      {/* Basic Usage */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Basic Usage
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField label="Name" placeholder="Enter your name" />
+          <TextField label="Email" placeholder="email@example.com" type="email" />
+          <TextField
+            label="Password"
+            placeholder="Enter password"
+            type="password"
+          />
+        </Flex>
+      </Flex>
+
+      {/* With Description */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          With Description
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField
+            label="Email"
+            placeholder="email@example.com"
+            description="We'll never share your email with anyone else."
+          />
+          <TextField
+            label="Username"
+            placeholder="johndoe"
+            description="Choose a unique username. This will be visible to others."
+          />
+        </Flex>
+      </Flex>
+
+      {/* Sizes */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Sizes
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField label="Small (32px)" placeholder="Small input" size="sm" />
+          <TextField
+            label="Medium (~47px)"
+            placeholder="Medium input"
+            size="md"
+          />
+        </Flex>
+      </Flex>
+
+      {/* States */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          States
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField
+            label="Default"
+            placeholder="Default text field"
+          />
+          <TextField
+            label="Disabled"
+            placeholder="Disabled text field"
+            isDisabled
+          />
+          <TextField
+            label="Read Only"
+            value="Read-only value"
+            isReadOnly
+          />
+        </Flex>
+      </Flex>
+
+      {/* Validation */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Validation
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField
+            label="Required Field"
+            placeholder="This field is required"
+            isRequired
+          />
+          <TextField
+            label="Invalid Field"
+            placeholder="Enter value"
+            isInvalid
+            errorMessage="This field has an error."
+          />
+          <TextField
+            label="Email with Validation"
+            placeholder="email@example.com"
+            type="email"
+            isInvalid
+            errorMessage="Please enter a valid email address."
+            description="Enter your work email."
+          />
+        </Flex>
+      </Flex>
+
+      {/* Form Example */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Form Example
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField
+            label="Full Name"
+            placeholder="John Doe"
+            isRequired
+          />
+          <TextField
+            label="Email Address"
+            placeholder="john@example.com"
+            type="email"
+            isRequired
+            description="We'll use this for account recovery."
+          />
+          <TextField
+            label="Password"
+            placeholder="Enter a strong password"
+            type="password"
+            isRequired
+            description="Must be at least 8 characters."
+          />
+          <Button size="lg" tone="primary">
+            Create Account
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* With Controlled Value */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          With Default Value
+        </Text>
+        <Flex direction="column" gap="300" style={styles.fieldContainer}>
+          <TextField
+            label="Pre-filled Field"
+            defaultValue="Default text value"
+          />
+          <TextField
+            label="Website"
+            defaultValue="https://example.com"
+            type="url"
+          />
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,7 @@
         "@urban-ui/reset": "workspace:*",
         "@urban-ui/styles": "workspace:*",
         "@urban-ui/text": "workspace:*",
+        "@urban-ui/textfield": "workspace:*",
         "@urban-ui/theme": "workspace:*",
         "lucide-react": "0.562.0",
         "react": "19.2.3",
@@ -350,6 +351,42 @@
       "name": "@urban-ui/input",
       "version": "0.1.0",
       "dependencies": {
+        "@urban-ui/theme": "workspace:*",
+        "react-aria-components": "1.14.0",
+      },
+      "devDependencies": {
+        "@happy-dom/jest-environment": "^20.3.3",
+        "@jest/globals": "^30.2.0",
+        "@rsbuild/plugin-react": "1.4.2",
+        "@rslib/core": "0.19.2",
+        "@stylexswc/jest": "0.14.2",
+        "@swc/jest": "^0.2.39",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^24",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@urban-ui/tsconfig": "workspace:*",
+        "del-cli": "^6.0.0",
+        "expect-type": "^1.2.1",
+        "jest": "^30.2.0",
+        "jest-chain-transform": "^0.0.8",
+        "react": "19.2.3",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "@stylexjs/stylex": "0.17.5",
+        "react": "19.2.3",
+      },
+    },
+    "packages/interaction/textfield": {
+      "name": "@urban-ui/textfield",
+      "version": "0.1.0",
+      "dependencies": {
+        "@urban-ui/form": "workspace:*",
+        "@urban-ui/input": "workspace:*",
         "@urban-ui/theme": "workspace:*",
         "react-aria-components": "1.14.0",
       },
@@ -1694,6 +1731,8 @@
     "@urban-ui/test2": ["@urban-ui/test2@workspace:packages/utility/test2"],
 
     "@urban-ui/text": ["@urban-ui/text@workspace:packages/typography/text"],
+
+    "@urban-ui/textfield": ["@urban-ui/textfield@workspace:packages/interaction/textfield"],
 
     "@urban-ui/theme": ["@urban-ui/theme@workspace:packages/core/theme"],
 

--- a/docs/balance.md
+++ b/docs/balance.md
@@ -34,9 +34,9 @@ Font sizes use a fluid type scale that responds to viewport width.
 
 | Size | Min (320px) | Max (1240px) | Use Case |
 |------|-------------|--------------|----------|
-| xxs  | 0.58rem (9px) | 0.53rem (8px) | Fine print, labels |
-| xs   | 0.69rem (11px) | 0.70rem (11px) | Captions, metadata |
-| sm   | 0.83rem (13px) | 0.94rem (15px) | Secondary text, descriptions |
+| xxs  | 0.58rem (9px) | 0.70rem (11px) | Fine print, labels |
+| xs   | 0.69rem (11px) | 0.88rem (14px) | Captions, metadata |
+| sm   | 0.83rem (13px) | 0.99rem (16px) | Secondary text, descriptions |
 | md   | 1rem (16px) | 1.25rem (20px) | Body text (baseline) |
 | lg   | 1.2rem (19px) | 1.67rem (27px) | Subheadings |
 | xl   | 1.44rem (23px) | 2.22rem (36px) | Headings |

--- a/docs/balance.md
+++ b/docs/balance.md
@@ -1,4 +1,4 @@
-# Interactive Elements
+# Balance
 
 Interactive elements should _feel_ like a cohesive unit so they can work together seamlessly. They should be balanced alongside text and other UI elements to create a harmonious interface.
 
@@ -34,13 +34,13 @@ Font sizes use a fluid type scale that responds to viewport width.
 
 | Size | Min (320px) | Max (1240px) | Use Case |
 |------|-------------|--------------|----------|
-| xxs  | 0.579rem (~9px) | 0.667rem (~11px) | Fine print, labels |
-| xs   | 0.694rem (~11px) | 0.889rem (~14px) | Captions, metadata |
-| sm   | 0.833rem (~13px) | 1.185rem (~19px) | Secondary text, descriptions |
+| xxs  | 0.58rem (9px) | 0.53rem (8px) | Fine print, labels |
+| xs   | 0.69rem (11px) | 0.70rem (11px) | Captions, metadata |
+| sm   | 0.83rem (13px) | 0.94rem (15px) | Secondary text, descriptions |
 | md   | 1rem (16px) | 1.25rem (20px) | Body text (baseline) |
-| lg   | 1.2rem (~19px) | 1.666rem (~27px) | Subheadings |
-| xl   | 1.44rem (~23px) | 2.221rem (~36px) | Headings |
-| xxl  | 1.728rem (~28px) | 2.961rem (~47px) | Display headings |
+| lg   | 1.2rem (19px) | 1.67rem (27px) | Subheadings |
+| xl   | 1.44rem (23px) | 2.22rem (36px) | Headings |
+| xxl  | 1.73rem (28px) | 2.96rem (47px) | Display headings |
 
 ## Interactive Element Size Composition
 

--- a/packages/core/theme/src/tokens/type.stylex.ts
+++ b/packages/core/theme/src/tokens/type.stylex.ts
@@ -25,10 +25,7 @@ const MAX_SCALE = 1.333
 const MIN_BASE_SIZE = 16
 const MAX_BASE_SIZE = 20
 
-// Using a scale factor of 1.2 (MIN_SCALE)
 // md is our baseline at 1rem (16px)
-// Each step up multiplies by 1.2
-// Each step down divides by 1.2
 
 // Font sizes in `rem` units
 const MIN_FONT = {
@@ -50,12 +47,12 @@ const MIN_FONT = {
 
 // Font sizes in `rem` units
 const MAX_FONT = {
-  // 0.53rem (8px)
-  xxs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 3 / 0.16) / 100,
   // 0.70rem (11px)
-  xs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 2 / 0.16) / 100,
-  // 0.94rem (15px)
-  sm: Math.round(MAX_BASE_SIZE / MAX_SCALE / 0.16) / 100,
+  xxs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 2 / 0.16) / 100,
+  // 0.88rem (14px)
+  xs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 1.2 / 0.16) / 100,
+  // 0.99rem (16px)
+  sm: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 0.8 / 0.16) / 100,
   // 1.25rem (20px) - baseline
   md: Math.round(MAX_BASE_SIZE / 0.16) / 100,
   // 1.67rem (27px)
@@ -91,11 +88,11 @@ const INTERCEPT = {
  * @css fontSize
  */
 export const fontSizes = defineVars({
-  // 0.58rem (9px) → 0.53rem (8px)
+  // 0.58rem (9px) → 0.70rem (11px)
   xxs: `clamp(${Math.min(MIN_FONT.xxs)}rem, calc(${INTERCEPT.xxs}rem + ${Math.round(10000 * SLOPE.xxs) / 100}vw), ${Math.max(MAX_FONT.xxs)}rem)`,
-  // 0.69rem (11px) → 0.70rem (11px)
+  // 0.69rem (11px) → 0.88rem (14px)
   xs: `clamp(${Math.min(MIN_FONT.xs)}rem, calc(${INTERCEPT.xs}rem + ${Math.round(10000 * SLOPE.xs) / 100}vw), ${Math.max(MAX_FONT.xs)}rem)`,
-  // 0.83rem (13px) → 0.94rem (15px)
+  // 0.83rem (13px) → 0.99rem (16px)
   sm: `clamp(${Math.min(MIN_FONT.sm)}rem, calc(${INTERCEPT.sm}rem + ${Math.round(10000 * SLOPE.sm) / 100}vw), ${Math.max(MAX_FONT.sm)}rem)`,
   // 1rem (16px) → 1.25rem (20px) - baseline
   md: `clamp(${Math.min(MIN_FONT.md)}rem, calc(${INTERCEPT.md}rem + ${Math.round(10000 * SLOPE.md) / 100}vw), ${Math.max(MAX_FONT.md)}rem)`,

--- a/packages/core/theme/src/tokens/type.stylex.ts
+++ b/packages/core/theme/src/tokens/type.stylex.ts
@@ -32,37 +32,37 @@ const MAX_BASE_SIZE = 20
 
 // Font sizes in `rem` units
 const MIN_FONT = {
-  // (16 / 1.2^3) / 0.16) / 100 = 0.579rem
+  // 0.58rem (9px)
   xxs: Math.round(MIN_BASE_SIZE / MIN_SCALE ** 3 / 0.16) / 100,
-  // (16 / 1.2^2) / 0.16) / 100 = 0.694rem
+  // 0.69rem (11px)
   xs: Math.round(MIN_BASE_SIZE / MIN_SCALE ** 2 / 0.16) / 100,
-  // (16 / 1.2) / 0.16) / 100 = 0.833rem
+  // 0.83rem (13px)
   sm: Math.round(MIN_BASE_SIZE / MIN_SCALE / 0.16) / 100,
-  // 16 / 0.16) / 100 = 1rem (baseline)
+  // 1rem (16px) - baseline
   md: Math.round(MIN_BASE_SIZE / 0.16) / 100,
-  // (16 * 1.2) / 0.16) / 100 = 1.2rem
+  // 1.2rem (19px)
   lg: Math.round((MIN_BASE_SIZE * MIN_SCALE) / 0.16) / 100,
-  // (16 * 1.2^2) / 0.16) / 100 = 1.44rem
+  // 1.44rem (23px)
   xl: Math.round((MIN_BASE_SIZE * MIN_SCALE ** 2) / 0.16) / 100,
-  // (16 * 1.2^3) / 0.16) / 100 = 1.728rem
+  // 1.73rem (28px)
   xxl: Math.round((MIN_BASE_SIZE * MIN_SCALE ** 3) / 0.16) / 100,
 }
 
 // Font sizes in `rem` units
 const MAX_FONT = {
-  // (20 / 1.333^3) / 0.16) / 100 = 0.667rem
+  // 0.53rem (8px)
   xxs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 3 / 0.16) / 100,
-  // (20 / 1.333^2) / 0.16) / 100 = 0.889rem
+  // 0.70rem (11px)
   xs: Math.round(MAX_BASE_SIZE / MAX_SCALE ** 2 / 0.16) / 100,
-  // (20 / 1.333) / 0.16) / 100 = 1.185rem
+  // 0.94rem (15px)
   sm: Math.round(MAX_BASE_SIZE / MAX_SCALE / 0.16) / 100,
-  // 20 / 0.16) / 100 = 1.25rem (baseline)
+  // 1.25rem (20px) - baseline
   md: Math.round(MAX_BASE_SIZE / 0.16) / 100,
-  // (20 * 1.333) / 0.16) / 100 = 1.666rem
+  // 1.67rem (27px)
   lg: Math.round((MAX_BASE_SIZE * MAX_SCALE) / 0.16) / 100,
-  // (20 * 1.333^2) / 0.16) / 100 = 2.221rem
+  // 2.22rem (36px)
   xl: Math.round((MAX_BASE_SIZE * MAX_SCALE ** 2) / 0.16) / 100,
-  // (20 * 1.333^3) / 0.16) / 100 = 2.961rem
+  // 2.96rem (47px)
   xxl: Math.round((MAX_BASE_SIZE * MAX_SCALE ** 3) / 0.16) / 100,
 }
 
@@ -91,19 +91,19 @@ const INTERCEPT = {
  * @css fontSize
  */
 export const fontSizes = defineVars({
-  // (0.579rem -> 0.667rem)
+  // 0.58rem (9px) → 0.53rem (8px)
   xxs: `clamp(${Math.min(MIN_FONT.xxs)}rem, calc(${INTERCEPT.xxs}rem + ${Math.round(10000 * SLOPE.xxs) / 100}vw), ${Math.max(MAX_FONT.xxs)}rem)`,
-  // (0.694rem -> 0.889rem)
+  // 0.69rem (11px) → 0.70rem (11px)
   xs: `clamp(${Math.min(MIN_FONT.xs)}rem, calc(${INTERCEPT.xs}rem + ${Math.round(10000 * SLOPE.xs) / 100}vw), ${Math.max(MAX_FONT.xs)}rem)`,
-  // (0.833rem -> 1.185rem)
+  // 0.83rem (13px) → 0.94rem (15px)
   sm: `clamp(${Math.min(MIN_FONT.sm)}rem, calc(${INTERCEPT.sm}rem + ${Math.round(10000 * SLOPE.sm) / 100}vw), ${Math.max(MAX_FONT.sm)}rem)`,
-  // (1rem -> 1.25rem) [baseline]
+  // 1rem (16px) → 1.25rem (20px) - baseline
   md: `clamp(${Math.min(MIN_FONT.md)}rem, calc(${INTERCEPT.md}rem + ${Math.round(10000 * SLOPE.md) / 100}vw), ${Math.max(MAX_FONT.md)}rem)`,
-  // (1.2rem -> 1.666rem)
+  // 1.2rem (19px) → 1.67rem (27px)
   lg: `clamp(${Math.min(MIN_FONT.lg)}rem, calc(${INTERCEPT.lg}rem + ${Math.round(10000 * SLOPE.lg) / 100}vw), ${Math.max(MAX_FONT.lg)}rem)`,
-  // (1.44rem -> 2.221rem)
+  // 1.44rem (23px) → 2.22rem (36px)
   xl: `clamp(${Math.min(MIN_FONT.xl)}rem, calc(${INTERCEPT.xl}rem + ${Math.round(10000 * SLOPE.xl) / 100}vw), ${Math.max(MAX_FONT.xl)}rem)`,
-  // (1.728rem -> 2.961rem)
+  // 1.73rem (28px) → 2.96rem (47px)
   xxl: `clamp(${Math.min(MIN_FONT.xxl)}rem, calc(${INTERCEPT.xxl}rem + ${Math.round(10000 * SLOPE.xxl) / 100}vw), ${Math.max(MAX_FONT.xxl)}rem)`,
 })
 

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -3,14 +3,12 @@
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
-import { space } from '@urban-ui/theme/layout.stylex'
 import type { TextProps as AriaTextProps } from 'react-aria-components'
 import { Text as AriaText } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    marginBlockStart: space[100],
   },
 })
 

--- a/packages/interaction/form/src/description.tsx
+++ b/packages/interaction/form/src/description.tsx
@@ -25,7 +25,7 @@ export interface DescriptionProps extends Omit<AriaTextProps, 'style' | 'slot'> 
  */
 export function Description({ children, style, ...props }: DescriptionProps) {
   return (
-    <Text asChild size="sm" color="lo" style={[styles.base, style]}>
+    <Text asChild size="xs" color="lo" style={[styles.base, style]}>
       <AriaText {...props} slot="description">
         {children}
       </AriaText>

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -4,14 +4,12 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
 import { themes } from '@urban-ui/theme'
-import { space } from '@urban-ui/theme/layout.stylex'
 import type { FieldErrorProps as AriaFieldErrorProps } from 'react-aria-components'
 import { FieldError as AriaFieldError } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    marginBlockStart: space[100],
   },
 })
 

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -28,7 +28,7 @@ export function FieldError({ children, style, ...props }: FieldErrorProps) {
   return (
     <Text
       asChild
-      size="sm"
+      size="xs"
       color="hi"
       style={[styles.base, themes.critical, style]}
     >

--- a/packages/interaction/form/src/field-error.tsx
+++ b/packages/interaction/form/src/field-error.tsx
@@ -10,6 +10,7 @@ import { FieldError as AriaFieldError } from 'react-aria-components'
 const styles = stylex.create({
   base: {
     display: 'block',
+    lineHeight: '1.2',
   },
 })
 

--- a/packages/interaction/form/src/form-field.tsx
+++ b/packages/interaction/form/src/form-field.tsx
@@ -1,0 +1,18 @@
+import * as stylex from '@stylexjs/stylex'
+import { space } from '@urban-ui/theme/layout.stylex'
+
+/**
+ * FormField styles for consistent form field layout.
+ * Apply to form field containers (e.g., AriaTextField) to get
+ * proper spacing between label, input, description, and error.
+ */
+export const formField = stylex.create({
+  /**
+   * Base layout for form fields - flex column with appropriate gap
+   */
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: space[100],
+  },
+})

--- a/packages/interaction/form/src/index.ts
+++ b/packages/interaction/form/src/index.ts
@@ -1,4 +1,5 @@
 export * from './form'
+export * from './form-field'
 export * from './label'
 export * from './description'
 export * from './field-error'

--- a/packages/interaction/form/src/label.tsx
+++ b/packages/interaction/form/src/label.tsx
@@ -3,14 +3,12 @@
 import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import { Text } from '@urban-ui/text'
-import { space } from '@urban-ui/theme/layout.stylex'
 import type { LabelProps as AriaLabelProps } from 'react-aria-components'
 import { Label as AriaLabel } from 'react-aria-components'
 
 const styles = stylex.create({
   base: {
     display: 'block',
-    marginBlockEnd: space[100],
   },
 })
 

--- a/packages/interaction/input/src/input.tsx
+++ b/packages/interaction/input/src/input.tsx
@@ -40,6 +40,10 @@ const styles = stylex.create({
     ':is(:focus-visible, [data-focus-visible])': {
       borderColor: accent.solid,
     },
+
+    ':where([data-invalid])': {
+      borderColor: critical.solid,
+    },
   },
   disabled: {
     ':disabled': {

--- a/packages/interaction/textfield/jest.config.js
+++ b/packages/interaction/textfield/jest.config.js
@@ -1,0 +1,66 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url))
+
+/** @type {import('jest').Config} */
+export default {
+  setupFilesAfterEnv: [path.join(rootDir, 'jest.setup.js')],
+  testEnvironment: '@happy-dom/jest-environment',
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx|mjs|cjs|html)$': [
+      'jest-chain-transform',
+      {
+        transformers: [
+          [
+            '@stylexswc/jest',
+            {
+              rsOptions: {
+                aliases: {
+                  '@/*': [path.join(rootDir, '*')],
+                },
+                unstable_moduleResolution: {
+                  type: 'commonJS',
+                },
+              },
+            },
+          ],
+          [
+            '@swc/jest',
+            {
+              $schema: 'https://json.schemastore.org/swcrc',
+              jsc: {
+                parser: {
+                  syntax: 'typescript',
+                  tsx: true,
+                  dynamicImport: true,
+                  decorators: true,
+                  dts: true,
+                },
+                transform: {
+                  react: {
+                    useBuiltins: true,
+                    runtime: 'automatic',
+                  },
+                },
+                target: 'esnext',
+                loose: false,
+                externalHelpers: false,
+                keepClassNames: true,
+                baseUrl: './',
+
+                paths: {
+                  '@/*': ['./*'],
+                },
+              },
+              module: {
+                type: 'es6',
+              },
+              minify: false,
+            },
+          ],
+        ],
+      },
+    ],
+  },
+}

--- a/packages/interaction/textfield/jest.setup.js
+++ b/packages/interaction/textfield/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/interaction/textfield/package.json
+++ b/packages/interaction/textfield/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@urban-ui/textfield",
+  "version": "0.1.0",
+  "type": "module",
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "lint": "biome lint src",
+    "format": "biome format src --write",
+    "typecheck": "tsc",
+    "clean": "del dist",
+    "dev": "rslib build --watch",
+    "build": "rslib build",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@urban-ui/form": "workspace:*",
+    "@urban-ui/input": "workspace:*",
+    "@urban-ui/theme": "workspace:*",
+    "react-aria-components": "1.14.0"
+  },
+  "peerDependencies": {
+    "react": "19.2.3",
+    "@stylexjs/stylex": "0.17.5"
+  },
+  "devDependencies": {
+    "@happy-dom/jest-environment": "^20.3.3",
+    "@jest/globals": "^30.2.0",
+    "@stylexswc/jest": "0.14.2",
+    "@swc/jest": "^0.2.39",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@rsbuild/plugin-react": "1.4.2",
+    "@rslib/core": "0.19.2",
+    "@urban-ui/tsconfig": "workspace:*",
+    "del-cli": "^6.0.0",
+    "expect-type": "^1.2.1",
+    "jest": "^30.2.0",
+    "jest-chain-transform": "^0.0.8",
+    "react": "19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/interaction/textfield/rslib.config.ts
+++ b/packages/interaction/textfield/rslib.config.ts
@@ -1,0 +1,30 @@
+import { pluginReact } from '@rsbuild/plugin-react'
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  lib: [
+    {
+      format: 'esm',
+      syntax: ['node 18'],
+      dts: true,
+      bundle: false,
+    },
+  ],
+  output: {
+    target: 'web',
+  },
+  source: {
+    entry: {
+      main: [
+        './src/**',
+        '!./src/**/*.test.ts',
+        '!./src/**/*.test.tsx',
+        '!./src/**/*.typetest.tsx',
+        '!./src/**/*.stories.tsx',
+        '!./src/**/*.spec.md',
+        '!./src/**/*.example.tsx',
+      ],
+    },
+  },
+})

--- a/packages/interaction/textfield/src/index.ts
+++ b/packages/interaction/textfield/src/index.ts
@@ -1,0 +1,1 @@
+export * from './textfield'

--- a/packages/interaction/textfield/src/textfield.test.tsx
+++ b/packages/interaction/textfield/src/textfield.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { TextField } from './textfield'
+
+describe('TextField', () => {
+  it('should render with a label', () => {
+    render(<TextField label="Email" data-testid="test-field" />)
+    expect(screen.getByText('Email')).toBeInTheDocument()
+  })
+
+  it('should render with a placeholder', () => {
+    render(<TextField placeholder="Enter email" data-testid="test-field" />)
+    expect(screen.getByPlaceholderText('Enter email')).toBeInTheDocument()
+  })
+
+  it('should render with description text', () => {
+    render(
+      <TextField
+        label="Email"
+        description="We'll never share your email"
+        data-testid="test-field"
+      />,
+    )
+    expect(screen.getByText("We'll never share your email")).toBeInTheDocument()
+  })
+
+  it('should handle user input', async () => {
+    const user = userEvent.setup()
+    render(<TextField label="Email" data-testid="test-field" />)
+
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'test@example.com')
+
+    expect(input).toHaveValue('test@example.com')
+  })
+
+  it('should handle disabled state', async () => {
+    const user = userEvent.setup()
+    render(<TextField label="Email" isDisabled data-testid="test-field" />)
+
+    const input = screen.getByRole('textbox')
+    expect(input).toBeDisabled()
+
+    await user.type(input, 'Test')
+    expect(input).toHaveValue('')
+  })
+
+  it('should apply size styles', () => {
+    render(<TextField label="Email" size="sm" data-testid="test-field" />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('should handle controlled value', () => {
+    render(
+      <TextField
+        label="Email"
+        value="test@example.com"
+        data-testid="test-field"
+      />,
+    )
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('test@example.com')
+  })
+
+  it('should handle name attribute for forms', () => {
+    render(<TextField label="Email" name="email" data-testid="test-field" />)
+    expect(screen.getByRole('textbox')).toHaveAttribute('name', 'email')
+  })
+
+  it('should handle type attribute', () => {
+    render(<TextField label="Password" type="password" data-testid="test-field" />)
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password')
+  })
+
+  it('should display error message when invalid', () => {
+    render(
+      <TextField
+        label="Email"
+        isInvalid
+        errorMessage="Invalid email address"
+        data-testid="test-field"
+      />,
+    )
+    expect(screen.getByText('Invalid email address')).toBeInTheDocument()
+  })
+
+  it('should be required when isRequired is true', () => {
+    render(<TextField label="Email" isRequired data-testid="test-field" />)
+    expect(screen.getByRole('textbox')).toBeRequired()
+  })
+})

--- a/packages/interaction/textfield/src/textfield.tsx
+++ b/packages/interaction/textfield/src/textfield.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import type { StyleXStyles } from '@stylexjs/stylex'
+import * as stylex from '@stylexjs/stylex'
+import { Description, FieldError, Label, formField } from '@urban-ui/form'
+import { Input } from '@urban-ui/input'
+import type {
+  TextFieldProps as AriaTextFieldProps,
+  ValidationResult,
+} from 'react-aria-components'
+import { TextField as AriaTextField } from 'react-aria-components'
+
+export interface TextFieldProps
+  extends Omit<AriaTextFieldProps, 'style' | 'children'> {
+  /**
+   * Label text for the field
+   */
+  label?: string
+
+  /**
+   * Description/helper text displayed below the input
+   */
+  description?: string
+
+  /**
+   * Error message to display when the field is invalid.
+   * Can be a string or a function that receives validation state.
+   */
+  errorMessage?: string | ((validation: ValidationResult) => string)
+
+  /**
+   * Placeholder text for the input
+   */
+  placeholder?: string
+
+  /**
+   * Size of the input
+   * @default 'md'
+   */
+  size?: 'sm' | 'md'
+
+  /**
+   * Additional styles to apply to the container
+   */
+  style?: StyleXStyles
+}
+
+/**
+ * TextField component built on react-aria-components.
+ * Composes Input with Label, Description, and FieldError for a complete form field.
+ */
+export function TextField({
+  label,
+  description,
+  errorMessage,
+  placeholder,
+  size = 'md',
+  style,
+  ...props
+}: TextFieldProps) {
+  return (
+    <AriaTextField {...props} {...stylex.props(formField.base, style)}>
+      {label && <Label>{label}</Label>}
+      <Input placeholder={placeholder} size={size} />
+      {description && <Description>{description}</Description>}
+      <FieldError>{errorMessage}</FieldError>
+    </AriaTextField>
+  )
+}
+TextField.displayName = '@urban-ui/textfield'

--- a/packages/interaction/textfield/tsconfig.json
+++ b/packages/interaction/textfield/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@urban-ui/tsconfig/client.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION

## Summary
Add TextField composite component that combines Input with Label, Description, and FieldError for complete form field functionality.

## Changes
- Add `@urban-ui/textfield` package with TextField component
- Add `formField` layout style to `@urban-ui/form` for consistent form field spacing
- Update Description and FieldError to use `xs` font size
- Add `data-invalid` border styling to Input component
- Fix fluid typography calculations in `type.stylex.ts` (MAX_FONT comments were incorrect)
- Rename `docs/interactive.md` to `docs/balance.md` with corrected values
- Add TextField demo route at `/patterns/textfield`
- Add "All Sizes" text example to `/patterns/text`

## Testing
- Run `bun run test --filter=@urban-ui/textfield` - 11 tests pass
- Run `bun run build` to verify builds succeed
- Visit `/patterns/textfield` in the tanstack app to see examples