### PR TITLE
Add form pattern example

### DIFF
--- a/apps/tanstack/package.json
+++ b/apps/tanstack/package.json
@@ -18,6 +18,7 @@
     "@urban-ui/center": "workspace:*",
     "@urban-ui/content": "workspace:*",
     "@urban-ui/flex": "workspace:*",
+    "@urban-ui/form": "workspace:*",
     "@urban-ui/icon": "workspace:*",
     "@urban-ui/input": "workspace:*",
     "@urban-ui/link": "workspace:*",

--- a/apps/tanstack/src/routes/patterns/form/route.tsx
+++ b/apps/tanstack/src/routes/patterns/form/route.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import * as stylex from '@stylexjs/stylex'
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Button } from '@urban-ui/button'
+import { Flex } from '@urban-ui/flex'
+import { Form } from '@urban-ui/form'
+import { Text } from '@urban-ui/text'
+import { TextField } from '@urban-ui/textfield'
+import { themes } from '@urban-ui/theme'
+import { radii } from '@urban-ui/theme/borders.stylex'
+import { base, tone } from '@urban-ui/theme/colors.stylex'
+import { space } from '@urban-ui/theme/layout.stylex'
+
+export const Route = createFileRoute('/patterns/form/')({
+  component: FormPatterns,
+})
+
+const styles = stylex.create({
+  page: {
+    padding: space[600],
+  },
+  container: {
+    padding: space[300],
+    backgroundColor: base.white,
+    color: tone.fgHi,
+    borderRadius: radii.md,
+  },
+  formContainer: {
+    maxWidth: '320px',
+  },
+  successMessage: {
+    padding: space[200],
+    backgroundColor: tone.surface,
+    color: tone.fgHi,
+    borderRadius: radii.sm,
+  },
+})
+
+function FormPatterns() {
+  const [submitted, setSubmitted] = useState(false)
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setSubmitted(true)
+  }
+
+  function handleReset() {
+    setSubmitted(false)
+  }
+
+  return (
+    <Flex direction="column" gap="400" style={[styles.page]}>
+      <Text size="xxl" weight="bold">
+        Form Patterns
+      </Text>
+
+      {/* Login Form */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Login Form
+        </Text>
+        <Text size="sm" color="lo">
+          Email and password form with client-side validation.
+        </Text>
+
+        <Form
+          onSubmit={handleSubmit}
+          style={styles.formContainer}
+          validationBehavior="native"
+        >
+          <Flex direction="column" gap="300">
+            <TextField
+              label="Email"
+              name="email"
+              type="email"
+              placeholder="you@example.com"
+              isRequired
+              description="We'll never share your email."
+            />
+
+            <TextField
+              label="Password"
+              name="password"
+              type="password"
+              placeholder="Enter your password"
+              isRequired
+              minLength={8}
+              description="Must be at least 8 characters."
+            />
+
+            <Flex gap="200">
+              <Button type="submit" tone="primary" size="lg">
+                Sign In
+              </Button>
+              <Button type="reset" tone="neutral" size="lg" onPress={handleReset}>
+                Reset
+              </Button>
+            </Flex>
+
+            {submitted && (
+              <div {...stylex.props(styles.successMessage, themes.positive)}>
+                <Text size="sm">Form submitted successfully!</Text>
+              </div>
+            )}
+          </Flex>
+        </Form>
+      </Flex>
+    </Flex>
+  )
+}

--- a/apps/tanstack/src/routes/patterns/form/route.tsx
+++ b/apps/tanstack/src/routes/patterns/form/route.tsx
@@ -2,7 +2,6 @@
 
 import * as stylex from '@stylexjs/stylex'
 import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
 import { Button } from '@urban-ui/button'
 import { Flex } from '@urban-ui/flex'
 import { Form } from '@urban-ui/form'
@@ -12,6 +11,7 @@ import { themes } from '@urban-ui/theme'
 import { radii } from '@urban-ui/theme/borders.stylex'
 import { base, tone } from '@urban-ui/theme/colors.stylex'
 import { space } from '@urban-ui/theme/layout.stylex'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/patterns/form/')({
   component: FormPatterns,
@@ -90,11 +90,16 @@ function FormPatterns() {
               description="Must be at least 8 characters."
             />
 
-            <Flex gap="200">
-              <Button type="submit" tone="primary" size="lg">
+            <Flex gap="200" justify="flex-end">
+              <Button type="submit" tone="primary" size="md">
                 Sign In
               </Button>
-              <Button type="reset" tone="neutral" size="lg" onPress={handleReset}>
+              <Button
+                type="reset"
+                tone="neutral"
+                size="md"
+                onPress={handleReset}
+              >
                 Reset
               </Button>
             </Flex>

--- a/bun.lock
+++ b/bun.lock
@@ -147,6 +147,7 @@
         "@urban-ui/center": "workspace:*",
         "@urban-ui/content": "workspace:*",
         "@urban-ui/flex": "workspace:*",
+        "@urban-ui/form": "workspace:*",
         "@urban-ui/icon": "workspace:*",
         "@urban-ui/input": "workspace:*",
         "@urban-ui/link": "workspace:*",


### PR DESCRIPTION

## Summary
- Add new form pattern example at `/patterns/form/` with email/password login form
- Uses TextField with native browser validation (required fields, email format, min length)
- Displays success message on valid submission using positive theme

## Test plan
- [ ] Run `bun run build` to verify the build passes
- [ ] Run `bun run typecheck` to verify types are correct
- [ ] Navigate to `/patterns/form/` in the tanstack demo app
- [ ] Test form validation by submitting empty fields
- [ ] Test email validation with invalid email format
- [ ] Test password min length validation
- [ ] Verify success message appears on valid submission