### PR TITLE
Restructure Menu components to match React Aria pattern

### DIFF
--- a/apps/tanstack/src/routes/patterns/menu/route.tsx
+++ b/apps/tanstack/src/routes/patterns/menu/route.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import * as stylex from '@stylexjs/stylex'
 import { createFileRoute } from '@tanstack/react-router'
 import { Button } from '@urban-ui/button'
@@ -13,11 +12,26 @@ import {
   Separator,
   SubmenuTrigger,
 } from '@urban-ui/menu'
-import { Popover } from '@urban-ui/popover'
 import { Text } from '@urban-ui/text'
 import { radii } from '@urban-ui/theme/borders.stylex'
 import { surface, tone } from '@urban-ui/theme/colors.stylex'
 import { space } from '@urban-ui/theme/layout.stylex'
+import {
+  Copy,
+  Ellipsis,
+  Facebook,
+  FolderOpen,
+  Instagram,
+  Linkedin,
+  Mail,
+  Pencil,
+  Share,
+  Smartphone,
+  Trash,
+  Twitter,
+} from 'lucide-react'
+import { useState } from 'react'
+import { Header, Text as AriaText } from 'react-aria-components'
 import type { Selection } from 'react-aria-components'
 
 export const Route = createFileRoute('/patterns/menu/')({
@@ -43,6 +57,77 @@ function MenuPatterns() {
         Menu Patterns
       </Text>
 
+      {/* Complete Example */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Complete Example
+        </Text>
+        <Text size="sm" color="lo">
+          Full-featured menu with icons, keyboard shortcuts, submenus, and
+          section selection.
+        </Text>
+        <MenuTrigger>
+          <Button aria-label="Actions">
+            <Ellipsis size={18} />
+          </Button>
+          <Menu>
+            <MenuSection>
+              <MenuItem onAction={() => alert('open')}>
+                <FolderOpen size={16} />
+                <AriaText slot="label">Open</AriaText>
+                <Keyboard>⌘O</Keyboard>
+              </MenuItem>
+              <MenuItem onAction={() => alert('rename')}>
+                <Pencil size={16} />
+                <AriaText slot="label">Rename…</AriaText>
+                <Keyboard>⌘R</Keyboard>
+              </MenuItem>
+              <MenuItem onAction={() => alert('duplicate')}>
+                <Copy size={16} />
+                <AriaText slot="label">Duplicate</AriaText>
+                <Keyboard>⌘D</Keyboard>
+              </MenuItem>
+              <MenuItem
+                onAction={() => alert('delete')}
+                variant="destructive"
+              >
+                <Trash size={16} />
+                <AriaText slot="label">Delete…</AriaText>
+                <Keyboard>⌘⌫</Keyboard>
+              </MenuItem>
+              <SubmenuTrigger>
+                <MenuItem>
+                  <Share size={16} />
+                  <AriaText slot="label">Share</AriaText>
+                </MenuItem>
+                <Menu>
+                  <MenuItem>
+                    <Mail size={16} />
+                    <AriaText slot="label">Email</AriaText>
+                  </MenuItem>
+                  <MenuItem>
+                    <Smartphone size={16} />
+                    <AriaText slot="label">SMS</AriaText>
+                  </MenuItem>
+                  <MenuItem>
+                    <Instagram size={16} />
+                    <AriaText slot="label">Instagram</AriaText>
+                  </MenuItem>
+                </Menu>
+              </SubmenuTrigger>
+            </MenuSection>
+            <Separator />
+            <MenuSection
+              selectionMode="multiple"
+              defaultSelectedKeys={['files']}
+            >
+              <MenuItem id="files">Show files</MenuItem>
+              <MenuItem id="folders">Show folders</MenuItem>
+            </MenuSection>
+          </Menu>
+        </MenuTrigger>
+      </Flex>
+
       {/* Basic Usage */}
       <Flex direction="v" gap="200" style={styles.container}>
         <Text size="lg" weight="semibold">
@@ -53,16 +138,14 @@ function MenuPatterns() {
         </Text>
         <MenuTrigger>
           <Button>Actions</Button>
-          <Popover>
-            <Menu
-              aria-label="Actions"
-              onAction={(key) => console.log('Action:', key)}
-            >
-              <MenuItem id="cut">Cut</MenuItem>
-              <MenuItem id="copy">Copy</MenuItem>
-              <MenuItem id="paste">Paste</MenuItem>
-            </Menu>
-          </Popover>
+          <Menu
+            aria-label="Actions"
+            onAction={(key) => console.log('Action:', key)}
+          >
+            <MenuItem id="cut">Cut</MenuItem>
+            <MenuItem id="copy">Copy</MenuItem>
+            <MenuItem id="paste">Paste</MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -72,31 +155,30 @@ function MenuPatterns() {
           With Keyboard Shortcuts
         </Text>
         <Text size="sm" color="lo">
-          Menu items can display keyboard shortcuts.
+          Menu items can display keyboard shortcuts using the Keyboard
+          component.
         </Text>
         <MenuTrigger>
           <Button>Edit</Button>
-          <Popover>
-            <Menu aria-label="Edit actions">
-              <MenuItem id="cut" textValue="Cut">
-                Cut
-                <Keyboard>⌘X</Keyboard>
-              </MenuItem>
-              <MenuItem id="copy" textValue="Copy">
-                Copy
-                <Keyboard>⌘C</Keyboard>
-              </MenuItem>
-              <MenuItem id="paste" textValue="Paste">
-                Paste
-                <Keyboard>⌘V</Keyboard>
-              </MenuItem>
-              <Separator />
-              <MenuItem id="selectAll" textValue="Select All">
-                Select All
-                <Keyboard>⌘A</Keyboard>
-              </MenuItem>
-            </Menu>
-          </Popover>
+          <Menu aria-label="Edit actions">
+            <MenuItem id="cut" textValue="Cut">
+              <AriaText slot="label">Cut</AriaText>
+              <Keyboard>⌘X</Keyboard>
+            </MenuItem>
+            <MenuItem id="copy" textValue="Copy">
+              <AriaText slot="label">Copy</AriaText>
+              <Keyboard>⌘C</Keyboard>
+            </MenuItem>
+            <MenuItem id="paste" textValue="Paste">
+              <AriaText slot="label">Paste</AriaText>
+              <Keyboard>⌘V</Keyboard>
+            </MenuItem>
+            <Separator />
+            <MenuItem id="selectAll" textValue="Select All">
+              <AriaText slot="label">Select All</AriaText>
+              <Keyboard>⌘A</Keyboard>
+            </MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -111,21 +193,19 @@ function MenuPatterns() {
         </Text>
         <MenuTrigger>
           <Button>File Actions</Button>
-          <Popover>
-            <Menu aria-label="File actions">
-              <MenuItem id="edit">Edit</MenuItem>
-              <MenuItem id="duplicate">Duplicate</MenuItem>
-              <Separator />
-              <MenuItem id="publish" variant="success">
-                Publish
-              </MenuItem>
-              <MenuItem id="archive">Archive</MenuItem>
-              <Separator />
-              <MenuItem id="delete" variant="destructive">
-                Delete
-              </MenuItem>
-            </Menu>
-          </Popover>
+          <Menu aria-label="File actions">
+            <MenuItem id="edit">Edit</MenuItem>
+            <MenuItem id="duplicate">Duplicate</MenuItem>
+            <Separator />
+            <MenuItem id="publish" variant="success">
+              Publish
+            </MenuItem>
+            <MenuItem id="archive">Archive</MenuItem>
+            <Separator />
+            <MenuItem id="delete" variant="destructive">
+              Delete
+            </MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -135,27 +215,26 @@ function MenuPatterns() {
           Sections with Headers
         </Text>
         <Text size="sm" color="lo">
-          Group related items with section headers.
+          Group related items with section headers. Use Header from
+          react-aria-components or MenuHeader.
         </Text>
         <MenuTrigger>
           <Button>File</Button>
-          <Popover>
-            <Menu aria-label="File menu">
-              <MenuSection>
-                <MenuHeader>Document</MenuHeader>
-                <MenuItem id="new">New</MenuItem>
-                <MenuItem id="open">Open</MenuItem>
-                <MenuItem id="save">Save</MenuItem>
-              </MenuSection>
-              <Separator />
-              <MenuSection>
-                <MenuHeader>Export</MenuHeader>
-                <MenuItem id="pdf">Export as PDF</MenuItem>
-                <MenuItem id="image">Export as Image</MenuItem>
-                <MenuItem id="markdown">Export as Markdown</MenuItem>
-              </MenuSection>
-            </Menu>
-          </Popover>
+          <Menu aria-label="File menu">
+            <MenuSection>
+              <Header>Document</Header>
+              <MenuItem id="new">New</MenuItem>
+              <MenuItem id="open">Open</MenuItem>
+              <MenuItem id="save">Save</MenuItem>
+            </MenuSection>
+            <Separator />
+            <MenuSection>
+              <MenuHeader>Export</MenuHeader>
+              <MenuItem id="pdf">Export as PDF</MenuItem>
+              <MenuItem id="image">Export as Image</MenuItem>
+              <MenuItem id="markdown">Export as Markdown</MenuItem>
+            </MenuSection>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -164,6 +243,9 @@ function MenuPatterns() {
 
       {/* Multiple Selection */}
       <MultipleSelectionExample />
+
+      {/* Section-Level Selection */}
+      <SectionSelectionExample />
 
       {/* Disabled Items */}
       <Flex direction="v" gap="200" style={styles.container}>
@@ -175,18 +257,16 @@ function MenuPatterns() {
         </Text>
         <MenuTrigger>
           <Button>Options</Button>
-          <Popover>
-            <Menu aria-label="Options">
-              <MenuItem id="view">View</MenuItem>
-              <MenuItem id="edit">Edit</MenuItem>
-              <MenuItem id="share" isDisabled>
-                Share (Unavailable)
-              </MenuItem>
-              <MenuItem id="delete" variant="destructive">
-                Delete
-              </MenuItem>
-            </Menu>
-          </Popover>
+          <Menu aria-label="Options">
+            <MenuItem id="view">View</MenuItem>
+            <MenuItem id="edit">Edit</MenuItem>
+            <MenuItem id="share" isDisabled>
+              Share (Unavailable)
+            </MenuItem>
+            <MenuItem id="delete" variant="destructive">
+              Delete
+            </MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -200,17 +280,15 @@ function MenuPatterns() {
         </Text>
         <MenuTrigger>
           <Button>Touch Menu</Button>
-          <Popover>
-            <Menu aria-label="Touch menu" size="lg">
-              <MenuItem id="profile">Profile</MenuItem>
-              <MenuItem id="settings">Settings</MenuItem>
-              <MenuItem id="help">Help</MenuItem>
-              <Separator />
-              <MenuItem id="logout" variant="destructive">
-                Log Out
-              </MenuItem>
-            </Menu>
-          </Popover>
+          <Menu aria-label="Touch menu" size="lg">
+            <MenuItem id="profile">Profile</MenuItem>
+            <MenuItem id="settings">Settings</MenuItem>
+            <MenuItem id="help">Help</MenuItem>
+            <Separator />
+            <MenuItem id="logout" variant="destructive">
+              Log Out
+            </MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -220,38 +298,41 @@ function MenuPatterns() {
           Submenus
         </Text>
         <Text size="sm" color="lo">
-          Nested menus for hierarchical navigation.
+          Nested menus for hierarchical navigation. No Popover wrapper needed.
         </Text>
         <MenuTrigger>
           <Button>Actions</Button>
-          <Popover>
-            <Menu aria-label="Actions with submenus">
-              <MenuItem id="cut">Cut</MenuItem>
-              <MenuItem id="copy">Copy</MenuItem>
-              <MenuItem id="paste">Paste</MenuItem>
-              <Separator />
-              <SubmenuTrigger>
-                <MenuItem id="share">Share</MenuItem>
-                <Popover>
-                  <Menu aria-label="Share options">
-                    <MenuItem id="email">Email</MenuItem>
-                    <MenuItem id="message">Message</MenuItem>
-                    <MenuItem id="airdrop">AirDrop</MenuItem>
-                    <SubmenuTrigger>
-                      <MenuItem id="social">Social Media</MenuItem>
-                      <Popover>
-                        <Menu aria-label="Social media options">
-                          <MenuItem id="twitter">Twitter</MenuItem>
-                          <MenuItem id="facebook">Facebook</MenuItem>
-                          <MenuItem id="linkedin">LinkedIn</MenuItem>
-                        </Menu>
-                      </Popover>
-                    </SubmenuTrigger>
+          <Menu aria-label="Actions with submenus">
+            <MenuItem id="cut">Cut</MenuItem>
+            <MenuItem id="copy">Copy</MenuItem>
+            <MenuItem id="paste">Paste</MenuItem>
+            <Separator />
+            <SubmenuTrigger>
+              <MenuItem id="share">Share</MenuItem>
+              <Menu aria-label="Share options">
+                <MenuItem id="email">Email</MenuItem>
+                <MenuItem id="message">Message</MenuItem>
+                <MenuItem id="airdrop">AirDrop</MenuItem>
+                <SubmenuTrigger>
+                  <MenuItem id="social">Social Media</MenuItem>
+                  <Menu aria-label="Social media options">
+                    <MenuItem id="twitter">
+                      <Twitter size={16} />
+                      <AriaText slot="label">Twitter</AriaText>
+                    </MenuItem>
+                    <MenuItem id="facebook">
+                      <Facebook size={16} />
+                      <AriaText slot="label">Facebook</AriaText>
+                    </MenuItem>
+                    <MenuItem id="linkedin">
+                      <Linkedin size={16} />
+                      <AriaText slot="label">LinkedIn</AriaText>
+                    </MenuItem>
                   </Menu>
-                </Popover>
-              </SubmenuTrigger>
-            </Menu>
-          </Popover>
+                </SubmenuTrigger>
+              </Menu>
+            </SubmenuTrigger>
+          </Menu>
         </MenuTrigger>
       </Flex>
 
@@ -265,14 +346,45 @@ function MenuPatterns() {
         </Text>
         <MenuTrigger trigger="longPress">
           <Button>Long Press Me</Button>
-          <Popover>
-            <Menu aria-label="Long press menu">
-              <MenuItem id="quick">Quick Action</MenuItem>
-              <MenuItem id="advanced">Advanced Options</MenuItem>
-            </Menu>
-          </Popover>
+          <Menu aria-label="Long press menu">
+            <MenuItem id="quick">Quick Action</MenuItem>
+            <MenuItem id="advanced">Advanced Options</MenuItem>
+          </Menu>
         </MenuTrigger>
       </Flex>
+
+      {/* Links */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Links
+        </Text>
+        <Text size="sm" color="lo">
+          Menu items can be links using the href prop.
+        </Text>
+        <MenuTrigger>
+          <Button>Resources</Button>
+          <Menu aria-label="Resource links">
+            <MenuItem
+              href="https://react-spectrum.adobe.com/react-aria/"
+              target="_blank"
+            >
+              React Aria Docs
+            </MenuItem>
+            <MenuItem href="https://stylexjs.com/" target="_blank">
+              StyleX Docs
+            </MenuItem>
+            <MenuItem
+              href="https://github.com/mattstyles/urban-ui"
+              target="_blank"
+            >
+              GitHub Repository
+            </MenuItem>
+          </Menu>
+        </MenuTrigger>
+      </Flex>
+
+      {/* Dynamic Collections */}
+      <DynamicCollectionExample />
     </Flex>
   )
 }
@@ -291,18 +403,16 @@ function SingleSelectionExample() {
       </Text>
       <MenuTrigger>
         <Button>View</Button>
-        <Popover>
-          <Menu
-            aria-label="View options"
-            selectionMode="single"
-            selectedKeys={selected}
-            onSelectionChange={setSelected}
-          >
-            <MenuItem id="list">List View</MenuItem>
-            <MenuItem id="grid">Grid View</MenuItem>
-            <MenuItem id="gallery">Gallery View</MenuItem>
-          </Menu>
-        </Popover>
+        <Menu
+          aria-label="View options"
+          selectionMode="single"
+          selectedKeys={selected}
+          onSelectionChange={setSelected}
+        >
+          <MenuItem id="list">List View</MenuItem>
+          <MenuItem id="grid">Grid View</MenuItem>
+          <MenuItem id="gallery">Gallery View</MenuItem>
+        </Menu>
       </MenuTrigger>
     </Flex>
   )
@@ -310,7 +420,7 @@ function SingleSelectionExample() {
 
 function MultipleSelectionExample() {
   const [selected, setSelected] = useState<Selection>(
-    new Set(['bold', 'italic'])
+    new Set(['bold', 'italic']),
   )
 
   return (
@@ -324,19 +434,91 @@ function MultipleSelectionExample() {
       </Text>
       <MenuTrigger>
         <Button>Format</Button>
-        <Popover>
-          <Menu
-            aria-label="Text formatting"
+        <Menu
+          aria-label="Text formatting"
+          selectionMode="multiple"
+          selectedKeys={selected}
+          onSelectionChange={setSelected}
+        >
+          <MenuItem id="bold">Bold</MenuItem>
+          <MenuItem id="italic">Italic</MenuItem>
+          <MenuItem id="underline">Underline</MenuItem>
+          <MenuItem id="strikethrough">Strikethrough</MenuItem>
+        </Menu>
+      </MenuTrigger>
+    </Flex>
+  )
+}
+
+function DynamicCollectionExample() {
+  const items = [
+    { id: 1, name: 'New file…' },
+    { id: 2, name: 'New window' },
+    { id: 3, name: 'Open…' },
+    { id: 4, name: 'Save' },
+    { id: 5, name: 'Save as…' },
+    { id: 6, name: 'Revert file' },
+  ]
+
+  return (
+    <Flex direction="v" gap="200" style={styles.container}>
+      <Text size="lg" weight="semibold">
+        Dynamic Collections
+      </Text>
+      <Text size="sm" color="lo">
+        Pass items array and render function for dynamic menu content.
+      </Text>
+      <MenuTrigger>
+        <Button>File</Button>
+        <Menu
+          aria-label="File menu"
+          items={items}
+          onAction={(key) => console.log('Action:', key)}
+        >
+          {(item) => <MenuItem>{item.name}</MenuItem>}
+        </Menu>
+      </MenuTrigger>
+    </Flex>
+  )
+}
+
+function SectionSelectionExample() {
+  const [style, setStyle] = useState<Selection>(new Set(['bold']))
+  const [align, setAlign] = useState<Selection>(new Set(['left']))
+
+  return (
+    <Flex direction="v" gap="200" style={styles.container}>
+      <Text size="lg" weight="semibold">
+        Section-Level Selection
+      </Text>
+      <Text size="sm" color="lo">
+        Each section can have independent selection. Style:{' '}
+        {[...style].join(', ')} | Align: {[...align].join(', ')}
+      </Text>
+      <MenuTrigger>
+        <Button>Format</Button>
+        <Menu aria-label="Text formatting">
+          <MenuSection
             selectionMode="multiple"
-            selectedKeys={selected}
-            onSelectionChange={setSelected}
+            selectedKeys={style}
+            onSelectionChange={setStyle}
           >
+            <Header>Text Style</Header>
             <MenuItem id="bold">Bold</MenuItem>
             <MenuItem id="italic">Italic</MenuItem>
             <MenuItem id="underline">Underline</MenuItem>
-            <MenuItem id="strikethrough">Strikethrough</MenuItem>
-          </Menu>
-        </Popover>
+          </MenuSection>
+          <MenuSection
+            selectionMode="single"
+            selectedKeys={align}
+            onSelectionChange={setAlign}
+          >
+            <Header>Alignment</Header>
+            <MenuItem id="left">Left</MenuItem>
+            <MenuItem id="center">Center</MenuItem>
+            <MenuItem id="right">Right</MenuItem>
+          </MenuSection>
+        </Menu>
       </MenuTrigger>
     </Flex>
   )

--- a/bun.lock
+++ b/bun.lock
@@ -395,6 +395,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@urban-ui/icon": "workspace:*",
+        "@urban-ui/popover": "workspace:*",
         "@urban-ui/text": "workspace:*",
         "@urban-ui/theme": "workspace:*",
       },

--- a/packages/interaction/menu/llms.md
+++ b/packages/interaction/menu/llms.md
@@ -1,6 +1,6 @@
 # @urban-ui/menu
 
-Menu component for displaying a list of actions or options. Supports action items, single/multiple selection, sections, separators, keyboard shortcuts, and nested submenus.
+Menu component for displaying a list of actions or options. Built on React Aria with urban-ui styling. Supports action items, single/multiple selection, sections, separators, keyboard shortcuts, links, and nested submenus.
 
 ## Installation
 
@@ -11,19 +11,31 @@ bun add @urban-ui/menu
 ## Quick Start
 
 ```tsx
-import { MenuTrigger, Menu, MenuItem } from '@urban-ui/menu'
-import { Popover } from '@urban-ui/popover'
+import { MenuTrigger, Menu, MenuItem, Separator, Keyboard } from '@urban-ui/menu'
 import { Button } from '@urban-ui/button'
+import { Text } from 'react-aria-components'
+import { Pencil, Copy, Trash } from 'lucide-react'
 
 <MenuTrigger>
   <Button>Actions</Button>
-  <Popover>
-    <Menu>
-      <MenuItem onAction={() => console.log('cut')}>Cut</MenuItem>
-      <MenuItem onAction={() => console.log('copy')}>Copy</MenuItem>
-      <MenuItem onAction={() => console.log('paste')}>Paste</MenuItem>
-    </Menu>
-  </Popover>
+  <Menu>
+    <MenuItem onAction={() => console.log('edit')}>
+      <Pencil size={16} />
+      <Text slot="label">Edit</Text>
+      <Keyboard>⌘E</Keyboard>
+    </MenuItem>
+    <MenuItem onAction={() => console.log('copy')}>
+      <Copy size={16} />
+      <Text slot="label">Copy</Text>
+      <Keyboard>⌘C</Keyboard>
+    </MenuItem>
+    <Separator />
+    <MenuItem onAction={() => console.log('delete')} variant="destructive">
+      <Trash size={16} />
+      <Text slot="label">Delete</Text>
+      <Keyboard>⌘⌫</Keyboard>
+    </MenuItem>
+  </Menu>
 </MenuTrigger>
 ```
 
@@ -31,14 +43,12 @@ import { Button } from '@urban-ui/button'
 
 ### MenuTrigger
 
-Manages open/close state and connects the trigger to the popover.
+Manages open/close state and wraps the Menu in a Popover automatically. The Popover is positioned below the trigger.
 
 ```tsx
 <MenuTrigger>
   <Button>Open Menu</Button>
-  <Popover>
-    <Menu>{/* items */}</Menu>
-  </Popover>
+  <Menu>{/* items */}</Menu>
 </MenuTrigger>
 ```
 
@@ -47,14 +57,22 @@ Manages open/close state and connects the trigger to the popover.
 - `defaultOpen?: boolean` - Uncontrolled default
 - `onOpenChange?: (isOpen: boolean) => void` - Open state callback
 - `trigger?: 'press' | 'longPress'` - How menu is triggered
+- `popoverStyle?: StyleXStyles` - Additional styles for the popover
 
 ### Menu
 
-Container for menu items with selection support.
+Container for menu items. Handles selection and keyboard navigation. Place directly inside MenuTrigger or SubmenuTrigger (they wrap it in a Popover automatically).
 
 ```tsx
-<Menu size="md" selectionMode="single" onAction={(key) => console.log(key)}>
+// Static collection
+<Menu onAction={(key) => console.log(key)}>
   <MenuItem id="edit">Edit</MenuItem>
+  <MenuItem id="delete">Delete</MenuItem>
+</Menu>
+
+// Dynamic collection
+<Menu items={items}>
+  {(item) => <MenuItem>{item.name}</MenuItem>}
 </Menu>
 ```
 
@@ -62,27 +80,38 @@ Container for menu items with selection support.
 - `size?: 'md' | 'lg'` - Size for all items (default: 'md')
 - `selectionMode?: 'none' | 'single' | 'multiple'` - Selection behavior
 - `selectedKeys?: Iterable<Key>` - Controlled selection
+- `defaultSelectedKeys?: Iterable<Key>` - Uncontrolled default selection
 - `onSelectionChange?: (keys: Selection) => void` - Selection callback
 - `onAction?: (key: Key) => void` - Action callback
 - `disabledKeys?: Iterable<Key>` - Disabled items
 - `items?: Iterable<T>` - Dynamic collection items
-- `style?: StyleXStyles` - Additional styles
+- `style?: StyleXStyles` - Additional styles for the menu
 
 ### MenuItem
 
 Individual menu item that can trigger an action or be selected.
 
 ```tsx
-// Simple
+import { Text } from 'react-aria-components'
+
+// Simple text
 <MenuItem>Edit</MenuItem>
 
-// With keyboard shortcut
+// With icon and keyboard shortcut
 <MenuItem textValue="Save">
-  Save
+  <SaveIcon />
+  <Text slot="label">Save</Text>
   <Keyboard>⌘S</Keyboard>
 </MenuItem>
 
-// Destructive
+// With description
+<MenuItem textValue="Copy">
+  <Text slot="label">Copy</Text>
+  <Text slot="description">Copy the selected text</Text>
+  <Keyboard>⌘C</Keyboard>
+</MenuItem>
+
+// Destructive action
 <MenuItem variant="destructive">Delete</MenuItem>
 ```
 
@@ -93,18 +122,45 @@ Individual menu item that can trigger an action or be selected.
 - `textValue?: string` - Text for typeahead/accessibility
 - `isDisabled?: boolean` - Disable interaction
 - `href?: string` - Make item a link
+- `target?: string` - Link target (e.g., '_blank')
 - `onAction?: () => void` - Action handler
 - `style?: StyleXStyles` - Additional styles
 
-### MenuSection & MenuHeader
+### MenuSection
 
-Group related items with an optional header.
+Groups related items with an optional header.
+
+```tsx
+import { Header } from 'react-aria-components'
+
+<Menu>
+  <MenuSection>
+    <Header>Export</Header>
+    <MenuItem>Image…</MenuItem>
+    <MenuItem>Video…</MenuItem>
+  </MenuSection>
+  <Separator />
+  <MenuSection selectionMode="multiple" defaultSelectedKeys={['files']}>
+    <MenuItem id="files">Show files</MenuItem>
+    <MenuItem id="folders">Show folders</MenuItem>
+  </MenuSection>
+</Menu>
+```
+
+**Props:**
+- `selectionMode?: 'none' | 'single' | 'multiple'` - Section-level selection
+- `selectedKeys?: Iterable<Key>` - Controlled selection for this section
+- `defaultSelectedKeys?: Iterable<Key>` - Default selection
+- `onSelectionChange?: (keys: Selection) => void` - Selection callback
+
+### MenuHeader
+
+Styled header for menu sections (alternative to `Header` from react-aria-components).
 
 ```tsx
 <MenuSection>
   <MenuHeader>Actions</MenuHeader>
   <MenuItem>Edit</MenuItem>
-  <MenuItem>Delete</MenuItem>
 </MenuSection>
 ```
 
@@ -114,37 +170,113 @@ Visual divider between items or sections.
 
 ```tsx
 <Menu>
-  <MenuItem>Cut</MenuItem>
+  <MenuItem>New…</MenuItem>
+  <MenuItem>Open…</MenuItem>
   <Separator />
-  <MenuItem>Paste</MenuItem>
+  <MenuItem>Save</MenuItem>
 </Menu>
 ```
 
 ### Keyboard
 
-Display keyboard shortcuts.
+Display keyboard shortcuts aligned to the right of menu items.
 
 ```tsx
 <MenuItem textValue="Copy">
-  Copy
+  <Text slot="label">Copy</Text>
   <Keyboard>⌘C</Keyboard>
 </MenuItem>
 ```
 
 ### SubmenuTrigger
 
-Create nested submenus.
+Create nested submenus. Wraps the Menu in a Popover automatically, positioned to the side.
 
 ```tsx
 <SubmenuTrigger>
-  <MenuItem>Share</MenuItem>
-  <Popover>
-    <Menu>
-      <MenuItem>Email</MenuItem>
-      <MenuItem>Message</MenuItem>
-    </Menu>
-  </Popover>
+  <MenuItem>
+    <Share size={16} />
+    <Text slot="label">Share</Text>
+  </MenuItem>
+  <Menu>
+    <MenuItem>
+      <Mail size={16} />
+      <Text slot="label">Email</Text>
+    </MenuItem>
+    <MenuItem>
+      <Smartphone size={16} />
+      <Text slot="label">SMS</Text>
+    </MenuItem>
+  </Menu>
 </SubmenuTrigger>
+```
+
+**Props:**
+- `delay?: number` - Delay in ms before submenu appears on hover (default: 200)
+- `popoverStyle?: StyleXStyles` - Additional styles for the popover
+
+## Complete Example
+
+```tsx
+import { MenuTrigger, Menu, MenuItem, MenuSection, Separator, Keyboard, SubmenuTrigger } from '@urban-ui/menu'
+import { Button } from '@urban-ui/button'
+import { Text, Header } from 'react-aria-components'
+import { Ellipsis, FolderOpen, Pencil, Copy, Trash, Share, Mail, Smartphone, Instagram } from 'lucide-react'
+
+<MenuTrigger>
+  <Button aria-label="Actions">
+    <Ellipsis size={18} />
+  </Button>
+  <Menu>
+    <MenuSection>
+      <MenuItem onAction={() => alert('open')}>
+        <FolderOpen size={16} />
+        <Text slot="label">Open</Text>
+        <Keyboard>⌘O</Keyboard>
+      </MenuItem>
+      <MenuItem onAction={() => alert('rename')}>
+        <Pencil size={16} />
+        <Text slot="label">Rename…</Text>
+        <Keyboard>⌘R</Keyboard>
+      </MenuItem>
+      <MenuItem onAction={() => alert('duplicate')}>
+        <Copy size={16} />
+        <Text slot="label">Duplicate</Text>
+        <Keyboard>⌘D</Keyboard>
+      </MenuItem>
+      <MenuItem onAction={() => alert('delete')} variant="destructive">
+        <Trash size={16} />
+        <Text slot="label">Delete…</Text>
+        <Keyboard>⌘⌫</Keyboard>
+      </MenuItem>
+      <SubmenuTrigger>
+        <MenuItem>
+          <Share size={16} />
+          <Text slot="label">Share</Text>
+        </MenuItem>
+        <Menu>
+          <MenuItem>
+            <Mail size={16} />
+            <Text slot="label">Email</Text>
+          </MenuItem>
+          <MenuItem>
+            <Smartphone size={16} />
+            <Text slot="label">SMS</Text>
+          </MenuItem>
+          <MenuItem>
+            <Instagram size={16} />
+            <Text slot="label">Instagram</Text>
+          </MenuItem>
+        </Menu>
+      </SubmenuTrigger>
+    </MenuSection>
+    <Separator />
+    <MenuSection selectionMode="multiple" defaultSelectedKeys={['files']}>
+      <MenuItem id="files">Show files</MenuItem>
+      <MenuItem id="folders">Show folders</MenuItem>
+    </MenuSection>
+  </Menu>
+</MenuTrigger>
 ```
 
 ## Common Patterns
@@ -161,40 +293,61 @@ function ViewMenu() {
   return (
     <MenuTrigger>
       <Button>View</Button>
-      <Popover>
-        <Menu
-          selectionMode="single"
-          selectedKeys={selected}
-          onSelectionChange={setSelected}
-        >
-          <MenuItem id="list">List</MenuItem>
-          <MenuItem id="grid">Grid</MenuItem>
-        </Menu>
-      </Popover>
+      <Menu
+        selectionMode="single"
+        selectedKeys={selected}
+        onSelectionChange={setSelected}
+      >
+        <MenuItem id="list">List View</MenuItem>
+        <MenuItem id="grid">Grid View</MenuItem>
+        <MenuItem id="gallery">Gallery View</MenuItem>
+      </Menu>
     </MenuTrigger>
   )
 }
 ```
 
+### Links
+
+```tsx
+<MenuTrigger>
+  <Button>Resources</Button>
+  <Menu>
+    <MenuItem href="https://react-spectrum.adobe.com/react-aria/" target="_blank">
+      React Aria Docs
+    </MenuItem>
+    <MenuItem href="https://stylexjs.com/" target="_blank">
+      StyleX Docs
+    </MenuItem>
+  </Menu>
+</MenuTrigger>
+```
+
 ### With Variants
 
 ```tsx
-<Menu>
-  <MenuItem>Edit</MenuItem>
-  <MenuItem>Duplicate</MenuItem>
-  <Separator />
-  <MenuItem variant="success">Publish</MenuItem>
-  <MenuItem variant="destructive">Delete</MenuItem>
-</Menu>
+<MenuTrigger>
+  <Button>Actions</Button>
+  <Menu>
+    <MenuItem>Edit</MenuItem>
+    <MenuItem>Duplicate</MenuItem>
+    <Separator />
+    <MenuItem variant="success">Publish</MenuItem>
+    <MenuItem variant="destructive">Delete</MenuItem>
+  </Menu>
+</MenuTrigger>
 ```
 
-### Large Size
+### Long Press Trigger
 
 ```tsx
-<Menu size="lg">
-  <MenuItem>Option 1</MenuItem>
-  <MenuItem>Option 2</MenuItem>
-</Menu>
+<MenuTrigger trigger="longPress">
+  <Button onPress={() => console.log('Primary action')}>Crop</Button>
+  <Menu>
+    <MenuItem>Rotate</MenuItem>
+    <MenuItem>Slice</MenuItem>
+  </Menu>
+</MenuTrigger>
 ```
 
 ## Keyboard Interactions
@@ -212,5 +365,5 @@ function ViewMenu() {
 ## Accessibility
 
 - Use `textValue` on MenuItem when children are not plain text
-- Sections without MenuHeader must have `aria-label`
-- Interactive elements inside menu items break keyboard navigation
+- Sections without a header must have `aria-label`
+- Interactive elements (buttons, links) inside menu items break keyboard navigation - only add text or decorative content as children

--- a/packages/interaction/menu/package.json
+++ b/packages/interaction/menu/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@urban-ui/icon": "workspace:*",
+    "@urban-ui/popover": "workspace:*",
     "@urban-ui/text": "workspace:*",
     "@urban-ui/theme": "workspace:*"
   },

--- a/packages/interaction/menu/src/menu-trigger.tsx
+++ b/packages/interaction/menu/src/menu-trigger.tsx
@@ -40,9 +40,7 @@ export function MenuTrigger({
   return (
     <AriaMenuTrigger {...props}>
       {trigger}
-      <Popover placement="bottom start" style={popoverStyle}>
-        {menu}
-      </Popover>
+      <Popover style={popoverStyle}>{menu}</Popover>
     </AriaMenuTrigger>
   )
 }

--- a/packages/interaction/menu/src/menu-trigger.tsx
+++ b/packages/interaction/menu/src/menu-trigger.tsx
@@ -1,27 +1,49 @@
 'use client'
 
+import type { StyleXStyles } from '@stylexjs/stylex'
+import { Popover } from '@urban-ui/popover'
+import { Children } from 'react'
 import type { MenuTriggerProps as AriaMenuTriggerProps } from 'react-aria-components'
 import { MenuTrigger as AriaMenuTrigger } from 'react-aria-components'
 
-export interface MenuTriggerProps extends AriaMenuTriggerProps {}
+export interface MenuTriggerProps extends AriaMenuTriggerProps {
+  /**
+   * Additional styles to apply to the popover
+   */
+  popoverStyle?: StyleXStyles
+}
 
 /**
  * Manages the open/close state of the menu and connects the trigger element to the popover.
+ * Automatically wraps the Menu child in a styled Popover.
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Actions</Button>
- *   <Popover>
- *     <Menu>
- *       <MenuItem>Cut</MenuItem>
- *       <MenuItem>Copy</MenuItem>
- *     </Menu>
- *   </Popover>
+ *   <Menu>
+ *     <MenuItem>Cut</MenuItem>
+ *     <MenuItem>Copy</MenuItem>
+ *   </Menu>
  * </MenuTrigger>
  * ```
  */
-export function MenuTrigger({ children, ...props }: MenuTriggerProps) {
-  return <AriaMenuTrigger {...props}>{children}</AriaMenuTrigger>
+export function MenuTrigger({
+  children,
+  popoverStyle,
+  ...props
+}: MenuTriggerProps) {
+  const childArray = Children.toArray(children)
+  const trigger = childArray[0]
+  const menu = childArray[1]
+
+  return (
+    <AriaMenuTrigger {...props}>
+      {trigger}
+      <Popover placement="bottom start" style={popoverStyle}>
+        {menu}
+      </Popover>
+    </AriaMenuTrigger>
+  )
 }
 MenuTrigger.displayName = '@urban-ui/menu-trigger'

--- a/packages/interaction/menu/src/menu.tsx
+++ b/packages/interaction/menu/src/menu.tsx
@@ -36,24 +36,23 @@ export interface MenuProps<T extends object>
   size?: MenuSize
 
   /**
-   * Additional styles to apply
+   * Additional styles to apply to the menu
    */
   style?: StyleXStyles
 }
 
 /**
- * Menu container managing items, selection, and keyboard navigation.
+ * Menu container for items, selection, and keyboard navigation.
+ * Place inside a Popover within MenuTrigger or SubmenuTrigger.
  *
  * @example
  * ```tsx
  * <MenuTrigger>
  *   <Button>Actions</Button>
- *   <Popover>
- *     <Menu>
- *       <MenuItem onAction={() => console.log('cut')}>Cut</MenuItem>
- *       <MenuItem onAction={() => console.log('copy')}>Copy</MenuItem>
- *     </Menu>
- *   </Popover>
+ *   <Menu>
+ *     <MenuItem onAction={() => console.log('cut')}>Cut</MenuItem>
+ *     <MenuItem onAction={() => console.log('copy')}>Copy</MenuItem>
+ *   </Menu>
  * </MenuTrigger>
  * ```
  */
@@ -65,7 +64,10 @@ export function Menu<T extends object>({
 }: MenuProps<T>) {
   return (
     <MenuProvider size={size}>
-      <AriaMenu {...props} {...stylex.props(styles.menu, sizeStyles[size], style)}>
+      <AriaMenu
+        {...props}
+        {...stylex.props(styles.menu, sizeStyles[size], style)}
+      >
         {children}
       </AriaMenu>
     </MenuProvider>

--- a/packages/interaction/menu/src/submenu-trigger.tsx
+++ b/packages/interaction/menu/src/submenu-trigger.tsx
@@ -1,27 +1,55 @@
 'use client'
 
+import type { StyleXStyles } from '@stylexjs/stylex'
+import { Popover } from '@urban-ui/popover'
+import { Children, type ReactElement, type ReactNode } from 'react'
 import type { SubmenuTriggerProps as AriaSubmenuTriggerProps } from 'react-aria-components'
 import { SubmenuTrigger as AriaSubmenuTrigger } from 'react-aria-components'
 
-export interface SubmenuTriggerProps extends AriaSubmenuTriggerProps {}
+export interface SubmenuTriggerProps
+  extends Omit<AriaSubmenuTriggerProps, 'children'> {
+  /**
+   * The trigger MenuItem and Menu content
+   */
+  children: ReactNode
+
+  /**
+   * Additional styles to apply to the popover
+   */
+  popoverStyle?: StyleXStyles
+}
 
 /**
- * Wraps a MenuItem and Popover to create a nested submenu.
+ * Wraps a MenuItem and Menu to create a nested submenu.
+ * Automatically wraps the Menu child in a styled Popover positioned to the side.
  *
  * @example
  * ```tsx
  * <SubmenuTrigger>
  *   <MenuItem>Share</MenuItem>
- *   <Popover>
- *     <Menu>
- *       <MenuItem>Email</MenuItem>
- *       <MenuItem>Message</MenuItem>
- *     </Menu>
- *   </Popover>
+ *   <Menu>
+ *     <MenuItem>Email</MenuItem>
+ *     <MenuItem>Message</MenuItem>
+ *   </Menu>
  * </SubmenuTrigger>
  * ```
  */
-export function SubmenuTrigger({ children, ...props }: SubmenuTriggerProps) {
-  return <AriaSubmenuTrigger {...props}>{children}</AriaSubmenuTrigger>
+export function SubmenuTrigger({
+  children,
+  popoverStyle,
+  ...props
+}: SubmenuTriggerProps) {
+  const childArray = Children.toArray(children)
+  const triggerItem = childArray[0] as ReactElement
+  const menu = childArray[1]
+
+  return (
+    <AriaSubmenuTrigger {...props}>
+      {triggerItem}
+      <Popover placement="end top" style={popoverStyle}>
+        {menu}
+      </Popover>
+    </AriaSubmenuTrigger>
+  )
 }
 SubmenuTrigger.displayName = '@urban-ui/submenu-trigger'


### PR DESCRIPTION

## Summary
Restructures the Menu component architecture so MenuTrigger and SubmenuTrigger contain the Popover internally, matching the React Aria vanilla starter pattern. This simplifies the consumer API.

## Changes
- Move Popover wrapper from Menu to MenuTrigger and SubmenuTrigger components
- MenuTrigger now wraps Menu child in Popover (uses default placement)
- SubmenuTrigger wraps Menu child in Popover with `placement="end top"` for side positioning
- Menu component now only renders menu content, no Popover
- Remove unnecessary Popover detection checks from trigger components
- Add `@urban-ui/popover` as dependency
- Update llms.md documentation with correct API examples
- Update tanstack demo app with simplified examples

## Testing
- Run `bun run test --filter=@urban-ui/menu` - all tests pass
- Run `bun run typecheck --filter=@urban-ui/menu` - no type errors
- Check tanstack demo app at `/patterns/menu` for visual verification