### PR TITLE
Refactor button styles to move padding to button element

### DIFF
--- a/apps/tanstack/src/routes/patterns/button/route.tsx
+++ b/apps/tanstack/src/routes/patterns/button/route.tsx
@@ -381,6 +381,57 @@ function PendingStateSection() {
         </Button>
       </Flex>
       <Text size="sm" color="lo">
+        Icon-only (md-equal):
+      </Text>
+      <Flex gap="200" wrap="wrap">
+        <Button
+          isPending={isPending}
+          onPress={handlePress}
+          tone="primary"
+          size="md-equal"
+          aria-label="Add"
+        >
+          <Icon size="md">
+            <Plus />
+          </Icon>
+        </Button>
+        <Button
+          isPending={isPending}
+          onPress={handlePress}
+          tone="positive"
+          size="md-equal"
+          aria-label="Download"
+        >
+          <Icon size="md">
+            <Download />
+          </Icon>
+        </Button>
+        <Button
+          isPending={isPending}
+          onPress={handlePress}
+          tone="critical"
+          size="md-equal"
+          variant="outline"
+          aria-label="Delete"
+        >
+          <Icon size="md">
+            <Trash2 />
+          </Icon>
+        </Button>
+        <Button
+          isPending={isPending}
+          onPress={handlePress}
+          tone="neutral"
+          size="md-equal"
+          variant="ghost"
+          aria-label="Send"
+        >
+          <Icon size="md">
+            <Send />
+          </Icon>
+        </Button>
+      </Flex>
+      <Text size="sm" color="lo">
         Always pending (static examples):
       </Text>
       <Flex gap="200" wrap="wrap">

--- a/apps/tanstack/src/routes/patterns/button/route.tsx
+++ b/apps/tanstack/src/routes/patterns/button/route.tsx
@@ -319,6 +319,56 @@ function ButtonPatterns() {
           </Button>
         </Flex>
       </Flex>
+
+      {/* Wrapping Elements */}
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Wrapping Elements
+        </Text>
+        <Text size="sm" color="lo">
+          Use variant=&quot;clear&quot; to wrap other elements and give them
+          button behavior without adding visual styling:
+        </Text>
+        <Flex gap="300" wrap="wrap">
+          <Button
+            variant="clear"
+            onPress={() => alert('Image clicked!')}
+            aria-label="View sunset image"
+          >
+            <img
+              src="https://picsum.photos/seed/sunset/160/120"
+              alt="Sunset landscape"
+              style={{ borderRadius: 8, display: 'block' }}
+            />
+          </Button>
+          <Button
+            variant="clear"
+            onPress={() => alert('Image clicked!')}
+            aria-label="View mountain image"
+          >
+            <img
+              src="https://picsum.photos/seed/mountain/160/120"
+              alt="Mountain landscape"
+              style={{ borderRadius: 8, display: 'block' }}
+            />
+          </Button>
+          <Button
+            variant="clear"
+            onPress={() => alert('Image clicked!')}
+            aria-label="View ocean image"
+          >
+            <img
+              src="https://picsum.photos/seed/ocean/160/120"
+              alt="Ocean landscape"
+              style={{ borderRadius: 8, display: 'block' }}
+            />
+          </Button>
+        </Flex>
+        <Text size="sm" color="lo">
+          This provides keyboard navigation, focus handling, and press events
+          while letting the wrapped content control its own appearance.
+        </Text>
+      </Flex>
     </Flex>
   )
 }

--- a/apps/tanstack/src/routes/patterns/link/route.tsx
+++ b/apps/tanstack/src/routes/patterns/link/route.tsx
@@ -135,6 +135,44 @@ function LinkPatterns() {
             <RouterLink to="/">Back Home</RouterLink>
           </Link>
         </Flex>
+        <Text size="sm" color="lo">
+          With icons (tests gap styling):
+        </Text>
+        <Flex gap="200" wrap="wrap">
+          <Link href="#icon" display="button" variant="solid" tone="primary">
+            <Home size="1em" />
+            Home
+          </Link>
+          <Link href="#icon" display="button" variant="muted" tone="neutral">
+            <Settings size="1em" />
+            Settings
+          </Link>
+          <Link href="#icon" display="button" variant="outline" tone="accent">
+            <Search size="1em" />
+            Search
+          </Link>
+          <Link href="#icon" display="button" variant="ghost" tone="info">
+            <Bell size="1em" />
+            Notifications
+          </Link>
+          <Link href="#icon" display="button" variant="solid" tone="positive">
+            <User size="1em" />
+            Profile
+          </Link>
+        </Flex>
+        <Text size="sm" color="lo">
+          Icon on right side:
+        </Text>
+        <Flex gap="200" wrap="wrap">
+          <Link href="#icon" display="button" variant="solid" tone="primary">
+            Continue
+            <Search size="1em" />
+          </Link>
+          <Link href="#icon" display="button" variant="outline" tone="neutral">
+            Open Settings
+            <Settings size="1em" />
+          </Link>
+        </Flex>
       </Flex>
 
       {/* Tones */}

--- a/docs/button.spec.md
+++ b/docs/button.spec.md
@@ -25,10 +25,27 @@ Button (AriaButton wrapper)
 ### Visual Hierarchy
 
 ```
-┌─────────────────────────────────────────┐
-│ [Icon?] Label Text [Icon?]              │
+┌─ Button ────────────────────────────────┐
+│ ┌─ [data-content] ───────────────────┐  │
+│ │ [Icon?] Label Text [Icon?]         │  │
+│ └────────────────────────────────────┘  │
+│ ┌─ ProgressBar (when isPending) ─────┐  │
+│ │ ◐ Spinner (absolute, centered)     │  │
+│ └────────────────────────────────────┘  │
 └─────────────────────────────────────────┘
 ```
+
+### Interior Content Element
+
+The Button component uses an interior `<span data-content>` element to wrap children. This element is required because:
+
+1. **Pending state overlay:** When `isPending` is true, the content must be hidden (via `opacity: 0`) while maintaining layout so the button doesn't collapse. The spinner overlays this content using absolute positioning.
+
+2. **Gap control:** The interior element provides the `gap` between child elements (e.g., icon and text). Moving gap to the button itself would affect the spinner positioning.
+
+3. **External styling target:** The `data-content` attribute allows external consumers to target the content wrapper for custom styling if needed.
+
+**Why not remove it?** We explored using CSS descendant selectors with `display: contents` on the spinner to hide children without a wrapper, but this approach doesn't work for text node children (which aren't matched by `> *` selectors).
 
 ---
 

--- a/packages/action/button/src/button.tsx
+++ b/packages/action/button/src/button.tsx
@@ -4,6 +4,7 @@ import type { StyleXStyles } from '@stylexjs/stylex'
 import * as stylex from '@stylexjs/stylex'
 import {
   content,
+  contentGap,
   shapes,
   sizes,
   styles,
@@ -108,11 +109,11 @@ const sizeMap: Record<keyof typeof sizes, StyleXStyles> = {
   'md-equal': sizes['md-equal'],
   'lg-equal': sizes['lg-equal'],
 }
-const contentSizeMap: Record<keyof typeof sizes, StyleXStyles> = {
-  md: content.md,
-  lg: content.lg,
-  'md-equal': content['md-equal'],
-  'lg-equal': content['lg-equal'],
+const gapMap: Record<keyof typeof sizes, StyleXStyles> = {
+  md: contentGap.md,
+  lg: contentGap.lg,
+  'md-equal': contentGap['md-equal'],
+  'lg-equal': contentGap['lg-equal'],
 }
 
 /**
@@ -130,8 +131,8 @@ export function Button({
   children,
   ...props
 }: ButtonProps) {
-  const [baseSize, contentSize] = useMemo(() => {
-    return [sizeMap[size], contentSizeMap[size]]
+  const [baseSize, gapSize] = useMemo(() => {
+    return [sizeMap[size], gapMap[size]]
   }, [size])
 
   return (
@@ -152,10 +153,11 @@ export function Button({
       {composeRenderProps(children, (children, { isPending }) => (
         <>
           <span
+            data-content=""
             {...stylex.props(
               content.base,
-              contentSize,
-              variant === 'clear' && content.clear,
+              gapSize,
+              variant === 'clear' && contentGap.clear,
               isPending && content.hidden,
             )}
           >

--- a/packages/core/styles/src/button.ts
+++ b/packages/core/styles/src/button.ts
@@ -16,7 +16,8 @@ export const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     position: 'relative',
-    padding: space[0],
+    // Padding is set by size variants (sizes.md, sizes.lg, etc.)
+    // and can be overridden by variants (e.g., clear sets padding to 0)
     borderColor: base.transparent,
     borderStyle: borderStyles.solid,
     borderWidth: borderWidths.md,
@@ -37,6 +38,8 @@ export const styles = stylex.create({
       boxShadow: `0 0 0 ${focusVars.outlineSize} ${base.white}`,
       zIndex: 1,
     },
+    // Content element layout - gap is applied to the [data-content] element
+    // while other layout properties are inherited from the button
   },
   disabled: {
     ':is(:disabled, [data-disabled])': {
@@ -56,6 +59,10 @@ export const styles = stylex.create({
   },
 })
 
+/**
+ * Content styles for the interior [data-content] element.
+ * Only controls opacity for pending state - layout is handled by button sizes.
+ */
 export const content = stylex.create({
   base: {
     display: 'flex',
@@ -68,29 +75,25 @@ export const content = stylex.create({
     transition: 'opacity 0s',
     opacity: 0,
   },
+})
+
+/**
+ * Gap styles for the interior [data-content] element, applied per size variant.
+ */
+export const contentGap = stylex.create({
   md: {
     gap: space['100'],
-    paddingInline: space['200'],
-    paddingBlock: space['25'],
   },
   lg: {
     gap: space['100'],
-    paddingInline: space['300'],
-    paddingBlock: space['50'],
   },
   'md-equal': {
     gap: space[0],
-    paddingInline: space['25'],
-    paddingBlock: space['25'],
   },
   'lg-equal': {
     gap: space[0],
-    paddingInline: space['50'],
-    paddingBlock: space['50'],
   },
   clear: {
-    paddingInline: space[0],
-    paddingBlock: space[0],
     gap: space[0],
   },
 })
@@ -98,34 +101,33 @@ export const content = stylex.create({
 /**
  * Buttons are sized by using a defined line height which matches the expected size of the icon at that size (which, in turn, is a font size). Text supplied to buttons as content can be plain strings, or set textbox to none for Text components.
  * Buttons are sized by their content and can handle overflow or differing content.
+ * Padding is applied to the button element itself, while gap is applied to the interior [data-content] element.
  */
 export const sizes = stylex.create({
   md: {
     fontSize: fontSizes.sm,
     // This is to provide a consistent height as we do not enforce cap heights for controls
     lineHeight: fontSizes.md,
-    // gap: space['100'],
-    // paddingInline: space['200'],
-    // paddingBlock: space['50'],
+    paddingInline: space['200'],
+    paddingBlock: space['25'],
     minHeight: control.md,
   },
   lg: {
     fontSize: fontSizes.md,
     lineHeight: fontSizes.lg,
-    // gap: space['100'],
-    // paddingInline: space['300'],
-    // paddingBlock: space['100'],
+    paddingInline: space['300'],
+    paddingBlock: space['50'],
     minHeight: control.lg,
   },
   'md-equal': {
-    // paddingInline: space['50'],
-    // paddingBlock: space['50'],
+    paddingInline: space['25'],
+    paddingBlock: space['25'],
     minHeight: control.md,
     minWidth: control.md,
   },
   'lg-equal': {
-    // paddingInline: space['100'],
-    // paddingBlock: space['100'],
+    paddingInline: space['50'],
+    paddingBlock: space['50'],
     minHeight: control.lg,
     minWidth: control.lg,
   },
@@ -147,8 +149,8 @@ export const variants = stylex.create({
   clear: {
     backgroundColor: base.transparent,
     color: tone.fgHi,
-    padding: space[0],
-    gap: space[0],
+    paddingInline: space[0],
+    paddingBlock: space[0],
   },
   solid: {
     backgroundColor: tone.solid,

--- a/packages/navigation/link/src/link.tsx
+++ b/packages/navigation/link/src/link.tsx
@@ -90,7 +90,7 @@ export function Link({
           buttonStyles.styles.base,
           buttonStyles.variants[buttonVariant],
           buttonStyles.content.base,
-          size ? buttonStyles.content[size] : buttonStyles.content.md,
+          size ? buttonStyles.contentGap[size] : buttonStyles.contentGap.md,
           size ? buttonStyles.sizes[size] : buttonStyles.sizes.md,
           shape ? buttonStyles.shapes[shape] : buttonStyles.shapes.rounded,
           tone ? tones[tone] : undefined,


### PR DESCRIPTION

## Summary
Refactors button styling to move padding from the interior content span to the button element itself, while keeping only gap on the interior element. Also adds `data-content` attribute to the interior element for external styling.

## Changes
- Move padding styles from `content.md/lg/etc` to `sizes.md/lg/etc` on the button element
- Create new `contentGap` export with gap-only styles per size variant
- Add `data-content` attribute to the interior span for external styling targets
- Update `content` styles to only control opacity for pending state
- Fix `variants.clear` to use longhand `paddingInline`/`paddingBlock` (fixes StyleX shorthand conflict)
- Update Link component to use new `contentGap` export when displayed as button
- Update button.spec.md with interior element documentation and visual hierarchy
- Add button-style link examples with icons to tanstack app (tests gap styling)
- Add icon-only pending button examples with md-equal size
- Add wrapping elements section demonstrating clear button around images

## Testing
- Run `bun run test:visual:docker` to verify no visual regressions
- Run `bun run dev` in `apps/tanstack` and navigate to `/patterns/button` and `/patterns/link` to verify gap is applied correctly between icons and text