### PR TITLE
Add table of contents to patterns index

### DIFF
--- a/apps/tanstack/src/routes/patterns/route.tsx
+++ b/apps/tanstack/src/routes/patterns/route.tsx
@@ -1,14 +1,76 @@
-import { createFileRoute } from '@tanstack/react-router'
+import * as stylex from '@stylexjs/stylex'
+import { createFileRoute, Link as RouterLink } from '@tanstack/react-router'
+import { Flex } from '@urban-ui/flex'
+import { Link } from '@urban-ui/link'
 import { Text } from '@urban-ui/text'
+import { radii } from '@urban-ui/theme/borders.stylex'
+import { base, tone } from '@urban-ui/theme/colors.stylex'
+import { space } from '@urban-ui/theme/layout.stylex'
 
 export const Route = createFileRoute('/patterns/')({
   component: PatternsIndex,
 })
 
+const styles = stylex.create({
+  page: {
+    padding: space[600],
+  },
+  container: {
+    padding: space[300],
+    backgroundColor: base.white,
+    color: tone.fgHi,
+    borderRadius: radii.md,
+  },
+  list: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  },
+  listItem: {
+    paddingBlock: space[100],
+  },
+})
+
+const patterns = [
+  { to: '/patterns/button', label: 'Button' },
+  { to: '/patterns/form', label: 'Form' },
+  { to: '/patterns/input', label: 'Input' },
+  { to: '/patterns/layout/center', label: 'Layout: Center' },
+  { to: '/patterns/layout/content', label: 'Layout: Content' },
+  { to: '/patterns/link', label: 'Link' },
+  { to: '/patterns/listbox', label: 'Listbox' },
+  { to: '/patterns/menu', label: 'Menu' },
+  { to: '/patterns/popover', label: 'Popover' },
+  { to: '/patterns/select', label: 'Select' },
+  { to: '/patterns/text', label: 'Text' },
+  { to: '/patterns/textfield', label: 'TextField' },
+] as const
+
 function PatternsIndex() {
   return (
-    <Text size="xl" weight="bold">
-      Patterns
-    </Text>
+    <Flex direction="column" gap="400" style={[styles.page]}>
+      <Text size="xxl" weight="bold">
+        Patterns
+      </Text>
+
+      <Flex direction="v" gap="200" style={styles.container}>
+        <Text size="lg" weight="semibold">
+          Table of Contents
+        </Text>
+        <nav aria-label="Pattern examples">
+          <ul {...stylex.props(styles.list)}>
+            {patterns.map(({ to, label }) => (
+              <li key={to} {...stylex.props(styles.listItem)}>
+                <Text>
+                  <Link asChild>
+                    <RouterLink to={to}>{label}</RouterLink>
+                  </Link>
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </Flex>
+    </Flex>
   )
 }


### PR DESCRIPTION

## Summary
- Adds a table of contents navigation to the `/patterns` route index page
- Links to all 12 existing pattern example pages
- Uses proper accessibility pattern: `<nav>` landmark with `aria-label` and semantic list

## Implementation
- Uses `Link asChild` with TanStack `RouterLink` for client-side navigation
- Follows existing styling patterns from other pattern pages
- Tab key navigation (the correct ARIA pattern for navigation links)

## Test plan
- [ ] Visit `/patterns` and verify all links render
- [ ] Tab through links to verify keyboard navigation
- [ ] Click links to verify routing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)