### PR TITLE
0.10.0 soft reset — foundation docs and planning skills

### DIFF
--- a/.agents/skills/breakdown/SKILL.md
+++ b/.agents/skills/breakdown/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: breakdown
+description: Convert an accepted plan into beads issues for implementation tracking. Creates an epic and one child issue per phase with dependencies. Use when a plan is accepted and ready for implementation, or when the user says "break this down", "create beads", "set up tracking".
+argument-hint: "<plan reference, e.g. docs/plans/020-workspace-snapshots.md>"
+---
+
+# Breakdown
+
+Convert a plan into beads issues for implementation tracking: `$ARGUMENTS`
+
+The breakdown skill bridges planning and implementation. It reads an accepted plan, creates a beads epic with child issues for each phase, and updates the plan file with bead IDs.
+
+## How to break down a plan
+
+### 1. Read the plan
+
+Read the plan file referenced in `$ARGUMENTS`. If no plan is specified, check `docs/plans/` for recent plans and ask the user which one to break down.
+
+Verify the plan has:
+- A goal
+- Numbered acceptance criteria
+- Defined phases with acceptance criteria
+
+If the plan looks incomplete or unaccepted, flag this to the user before proceeding.
+
+### 2. Create the epic
+
+Create a beads epic for the overall plan:
+
+- **Title**: the plan's goal
+- **Type**: `feature`
+- **Priority**: match the urgency the user has conveyed (default to 2 if unclear)
+- **Description**: summary of what the plan delivers, with links to the plan file and the upstream artefact (if the plan's frontmatter has a `source` field — typically a PRD or idea file). Include a completion ritual: when the final phase's PR is open, on that same branch prepend ✅ to the plan's `# Title` heading and run `bd close <epic-id>` — both changes ride in the final phase's PR, no separate epic-tick PR.
+
+### 3. Create phase issues
+
+For each phase in the plan, create a child beads issue using the issue body template at `${CLAUDE_SKILL_DIR}/references/issue-body-template.md`:
+
+- **Title**: the phase goal
+- **Type**: `task` (or `feature` if the phase delivers user-facing functionality)
+- **Description**: contains:
+  - What this phase delivers (the vertical slice)
+  - Phase acceptance criteria
+  - Which plan-level ACs this phase covers
+  - Completion ritual (single PR — no follow-up): once the implementation PR is open and its URL is known, on the **same** feature branch:
+    1. Prepend ✅ to this phase's heading in the plan file and append the PR URL (e.g. `### ✅ Phase 1: [Goal] — beads-abc123 — https://github.com/surgeventures/xenon/pull/14`).
+    2. Run `bd close <bead-id>` to close this issue (mutates `.beads/issues.jsonl`).
+    3. Commit both changes and push — they land in the same PR. Merge after.
+
+Wire dependencies (`bd dep add <dependent> <dependency>`):
+- Each phase depends on the previous phase: `bd dep add <phase-N> <phase-N-1>`
+- The epic depends on every phase: `bd dep add <epic> <phase-N>` for each phase
+
+### 4. Update the plan file
+
+After creating all beads, update the plan document on disk so each phase heading includes its bead ID:
+
+```
+### Phase 1: [Goal] — beads-abc123
+```
+
+On phase completion, prepend ✅ to the heading (the requirement to do this lives in the bead itself):
+
+```
+### ✅ Phase 1: [Goal] — beads-abc123
+```
+
+When every phase is complete, prepend ✅ to the plan's `# Title` heading too.
+
+This keeps the plan file as the single source of truth linking phases to their tracking issues, with completion state visible alongside the bead reference.
+
+### 5. Confirm
+
+Report to the user:
+- Epic bead ID and title
+- Each phase bead ID and title
+- Dependency chain
+
+## Boundaries
+
+- Reads the plan — does not modify it (except adding bead IDs to phase headings)
+- Does not start implementation
+- Does not create sub-issues within a phase (a phase = one bead)
+- Does not modify the PRD

--- a/.agents/skills/breakdown/references/issue-body-template.md
+++ b/.agents/skills/breakdown/references/issue-body-template.md
@@ -1,0 +1,7 @@
+Phase N: [Goal]
+Source: docs/plans/NNN-slug.md
+Delivers: [the vertical slice]
+Covers: AC <numbers>
+
+Acceptance Criteria:
+- [Phase-specific ACs]

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: plan
+description: Create a structured, phased implementation plan before writing any code. Use this skill whenever the user wants to plan work, design an approach, break down a feature, scope a change, or think through how to implement something before doing it. Trigger on phrases like "let's plan", "how should we approach", "break this down", "what's the plan for", "scope this out", or any request that benefits from structured thinking before implementation. If a task is non-trivial and no plan exists yet, suggest using this skill.
+argument-hint: "<PRD reference or description of what to build or change>"
+---
+
+# Plan
+
+Create a phased implementation plan for: `$ARGUMENTS`
+
+Planning comes before implementation. No code gets written, no files get changed, until the plan is accepted. The purpose of a plan is to think clearly, surface problems early, and break work into vertical slices that each leave the system in a deployable state.
+
+Read the vertical slices reference at `${CLAUDE_SKILL_DIR}/references/vertical-slices.md` to understand the phasing constraint.
+
+## How to produce the plan
+
+Draft sections 1–6 below in order, outputting each section as you go. Then run the Assessment (section 7) to revise, then Acceptance (section 8) to iterate with the user, and finally Write to disk (section 9) once the plan is accepted. The plan is a conversation — the user will push back, ask questions, and request changes. That's the point.
+
+### 1. Gather context
+
+- If `$ARGUMENTS` references a PRD (e.g. `docs/prds/005-workspace-snapshots.md`), read it. The PRD's problem, needle, solution, and user stories are the foundation.
+- If gorilla ran earlier in this conversation, use the resolved decisions and constraints.
+- If starting from a freeform description, treat `$ARGUMENTS` as the basis.
+- Explore the codebase to understand the current state — existing behaviour, relevant code, constraints.
+
+### 2. Goal
+
+State what we want to achieve in 1–2 sentences. Be specific about the outcome, not the method. If working from a PRD, derive the goal from the problem and needle. If the user's request is vague, sharpen it — don't just echo it back.
+
+### 3. Acceptance Criteria
+
+Define a numbered list of observable, testable outcomes that determine when the plan is complete. These should be things you can verify by doing — not by reading code.
+
+If working from a PRD, link each criterion to the user stories it satisfies (e.g. `AC 1: [criterion] (traces to User Story 3, 7)`). Every user story should be covered by at least one AC.
+
+Good acceptance criteria are specific enough that two people would agree on whether each one has been met. "The feature works" is not testable. "Submit 'create a login page' in the prompt input and see a login form render in the iframe within 60 seconds" is.
+
+### 4. Design Decisions
+
+List architectural and technical choices that constrain the implementation. These are not code-level details — they're the significant choices that shape the approach.
+
+For each decision, state the choice and the rationale. If alternatives were considered, note why they were rejected. If a decision was made during an earlier gorilla or PRD session, reference it rather than re-deriving it.
+
+### 5. Risks
+
+Identify what could go wrong or get complicated:
+
+- **Technical risks** — things that might not work as expected, unknowns, performance concerns
+- **Scope risks** — things that could expand beyond the stated goal, rabbit holes
+- **Integration risks** — things that could break existing behaviour or conflict with other work
+
+For each risk: severity (high / medium / low) and a mitigation if you have one. Don't pad this section — if there are genuinely few risks, say so.
+
+Risks inform phase ordering — higher-risk phases go first to surface problems early, when there's still room to change course.
+
+### 6. Phases
+
+Break the work into phases. The critical constraints:
+
+- **Every phase is a vertical slice.** Each phase delivers a thin but complete path through the product — from user action to observable outcome. No horizontal layers. Read `${CLAUDE_SKILL_DIR}/references/vertical-slices.md`.
+- **Every phase is deployable.** The system should be shippable after any phase completes, even if later phases never happen.
+- **Risk-first ordering.** Higher-risk phases come first to uncover problems early.
+
+Format each phase using the structure from `${CLAUDE_SKILL_DIR}/references/phase-template.md`.
+
+Each phase must list which plan-level ACs it covers. Every AC must appear in at least one phase. Phase-level ACs are more granular than plan-level ACs and should describe user-observable outcomes.
+
+Prefer more phases with fewer concerns over fewer phases with many concerns.
+
+### 7. Assessment
+
+Step back and critically assess the plan. This is AI-driven — do the work, don't just list concerns:
+
+- **Viability** — will this actually work? Are there technical assumptions that haven't been validated?
+- **Inconsistencies** — do the phases contradict each other? Do the ACs conflict?
+- **Omissions** — what's missing? Are there user stories from the PRD that aren't covered?
+- **Vertical slices** — is every phase a genuine vertical slice, or are any phases horizontal layers masquerading as slices?
+- **Risk ordering** — are higher-risk phases genuinely front-loaded?
+- **Simplification** — can phases be merged or removed? Is there unnecessary complexity?
+
+If the assessment reveals problems, revise the plan and call out what you changed and why.
+
+### 8. Acceptance
+
+Present the complete plan to the user and ask rigorous questions to verify shared understanding — similar to gorilla but focused on confirming alignment rather than deep exploration. The plan should be mostly correct by this point; acceptance is a final verification.
+
+When the user requests changes, revise the plan, re-run the assessment, and re-present. Always show the complete picture, not just a diff. Do NOT write to disk while iterating.
+
+Keep iterating until the user explicitly accepts.
+
+### 9. Write to disk
+
+Only after explicit acceptance, write the plan to disk.
+
+Determine the next available number by checking existing files in `docs/plans/`. If the directory does not exist, create it and start at `001`. Use the format `NNN` (zero-padded to 3 digits).
+
+Write to `docs/plans/NNN-slug.md` using the template at `${CLAUDE_SKILL_DIR}/references/plan-template.md`. The slug should be short kebab-case derived from the goal. Populate the YAML frontmatter:
+
+- `title` — the plan title
+- `source` — path to the upstream artefact (PRD or idea file), if the plan was driven from one (omit if not applicable)
+
+Confirm the file was written.
+
+## On acceptance
+
+After writing the plan to disk, offer to run the breakdown skill to create beads issues for implementation tracking. Do NOT create beads directly — that's the breakdown skill's responsibility.
+
+## Boundaries
+
+- No step-by-step action checklists within phases — the implementer determines how using TDD
+- No code changes
+- No beads creation (that's the breakdown skill)

--- a/.agents/skills/plan/references/phase-template.md
+++ b/.agents/skills/plan/references/phase-template.md
@@ -1,0 +1,8 @@
+### Phase N: [Goal]
+
+Delivers: [what's deployable after this phase — a vertical slice]
+Covers: AC <numbers>
+
+#### Acceptance Criteria
+
+- [Granular, phase-specific ACs derived from user journeys]

--- a/.agents/skills/plan/references/plan-template.md
+++ b/.agents/skills/plan/references/plan-template.md
@@ -1,0 +1,36 @@
+---
+title: "Title"
+source: ""
+---
+
+# Title
+
+## Goal
+
+[1-2 sentences. What we're achieving. Derived from PRD if available]
+
+## Acceptance Criteria
+
+[Numbered list. High-level, linked to PRD user stories. Observable, testable outcomes]
+
+1. [Criterion] (traces to User Story N)
+
+## Design Decisions
+
+[Architectural/technical choices that constrain implementation. Not code-level details]
+
+- [Decision and rationale]
+
+## Risks
+
+[Technical, scope, integration. Severity + mitigation. Informs phase ordering — higher-risk phases go first]
+
+- [Risk]: [high/medium/low] — [mitigation]
+
+## Phases
+
+[One section per phase using the structure in `references/phase-template.md`]
+
+## Assessment
+
+[AI-driven critique of the plan: viability, inconsistencies, omissions, simplification opportunities]

--- a/.agents/skills/plan/references/vertical-slices.md
+++ b/.agents/skills/plan/references/vertical-slices.md
@@ -1,0 +1,21 @@
+# Vertical Slices
+
+A vertical slice is a phase of work that delivers a thin but complete path through the product — from user action to observable outcome. It touches every layer needed (UI, API, database, infrastructure) but only the minimum of each to deliver one coherent piece of value.
+
+## The test
+
+Can a user (or the team) do something new after this phase that they couldn't before?
+
+If the answer is "no, but the database schema is ready" — it's a horizontal layer, not a vertical slice.
+
+## Examples
+
+**Vertical slice**: "A user can create a workspace snapshot and see it listed" — touches API, storage, UI, but only the happy path.
+
+**Not a vertical slice**: "Set up the snapshot database tables and migrations" — enables future work but delivers nothing observable.
+
+## Why this matters
+
+- Phase acceptance criteria must describe user-observable outcomes
+- Risk-first ordering still applies — if the risky part is the storage layer, the first slice still goes end-to-end, it just picks the slice that exercises the risky layer
+- Every phase leaves the system in a deployable state with new capability

--- a/.agents/skills/prd/SKILL.md
+++ b/.agents/skills/prd/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: prd
+description: Create a Product Requirements Document — problem, needle, solution, and user stories. Use when the user wants to write a PRD, define requirements, formalize an idea, or says "let's write a PRD", "requirements for...", "define this feature".
+argument-hint: "<idea reference or description of what to define>"
+---
+
+# PRD
+
+Create a PRD for: `$ARGUMENTS`
+
+A PRD defines the problem space — what we're solving and for whom. It does not define how to build it. The PRD is the input to the plan skill, which handles implementation design.
+
+## How to produce the PRD
+
+### 1. Gather context
+
+- If `$ARGUMENTS` references an idea file (e.g. `docs/ideas/005-workspace-snapshots.md`), read it as the starting point.
+- If gorilla ran earlier in this conversation, use the resolved decisions and constraints.
+- If starting from scratch, ask the user to describe the problem they want to solve.
+
+### 2. Assess readiness
+
+If the problem space feels underexplored — the user can't clearly articulate the problem, the solution direction is vague, or there are many open questions — offer to run gorilla first. Don't force it, just offer.
+
+### 3. Build the PRD
+
+Work through the four sections of the template at `${CLAUDE_SKILL_DIR}/references/template.md`:
+
+**Problem** — Terse. What's broken or missing, who's affected. Don't pad this — if it takes more than a few sentences, the problem isn't well understood yet.
+
+**Needle** — Terse, positive framing. What changes in the world if we solve this. This is not the solution — it's the outcome. One or two sentences.
+
+**Solution** — From the user's perspective. Elaborates on the needles being moved. Describes the shape of the solution without implementation details. This section can be longer — it should give enough detail that someone reading it understands what we're building and why.
+
+**User Stories** — Extensive numbered list covering the full surface of the solution. Each story follows: `As a [actor], I want [feature], so that [benefit]`. These become the raw material for plan phases and acceptance criteria, so thoroughness matters. Push for completeness — it's cheaper to cut stories later than to discover missing ones during implementation.
+
+Explore the codebase as needed to ground the PRD in reality — existing behaviour, relevant code, constraints that affect the solution.
+
+### 4. Assess the PRD
+
+Before presenting for acceptance, critically review the PRD:
+
+- Does the problem statement actually describe a problem?
+- Does the needle articulate a positive change, not just restate the problem?
+- Does the solution stay in the problem space (no implementation details)?
+- Do the user stories cover the full surface of the solution?
+- Are there implicit assumptions that should be explicit in the solution?
+
+Fix any issues found. This assessment is AI-driven — present findings and revisions to the user, don't just note them.
+
+### 5. Acceptance
+
+Present the complete PRD to the user. Ask rigorous questions to verify shared understanding — similar to gorilla but lighter, focused on confirming alignment rather than deep exploration. The PRD should be mostly correct by this point; acceptance is a final verification.
+
+Iterate until the user explicitly accepts.
+
+### 6. Write to disk
+
+Determine the next available number by checking existing files in `docs/prds/`. If the directory does not exist, create it and start at `001`. Use the format `NNN` (zero-padded to 3 digits).
+
+Write to `docs/prds/NNN-slug.md` using the template format. The slug should be short kebab-case derived from the title. Populate the YAML frontmatter:
+
+- `title` — the PRD title
+- `source` — path to the idea file, if the PRD was driven from one (omit if not applicable)
+
+Confirm the file was written.
+
+## Boundaries
+
+- No implementation details — that's the plan's job
+- No phased breakdowns, no acceptance criteria — those come from planning
+- No beads creation
+- No changelog or revision tracking — git handles that

--- a/.agents/skills/prd/references/template.md
+++ b/.agents/skills/prd/references/template.md
@@ -1,0 +1,22 @@
+---
+title: "Title"
+source: ""
+---
+
+# Title
+
+## Problem
+
+[Terse. What's broken or missing, who's affected]
+
+## Needle
+
+[Terse, positive. What changes in the world if we solve this]
+
+## Solution
+
+[User's perspective. Elaborates on the needles being moved. Not implementation details]
+
+## User Stories
+
+1. As a [actor], I want [feature], so that [benefit]

--- a/.claude/skills/breakdown
+++ b/.claude/skills/breakdown
@@ -1,0 +1,1 @@
+../../.agents/skills/breakdown

--- a/.claude/skills/plan
+++ b/.claude/skills/plan
@@ -1,0 +1,1 @@
+../../.agents/skills/plan

--- a/.claude/skills/prd
+++ b/.claude/skills/prd
@@ -1,0 +1,1 @@
+../../.agents/skills/prd

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# GitHub token for changelog generation (needs repo or public_repo scope)
-# Create at: https://github.com/settings/tokens
-GITHUB_TOKEN=
-
 # NPM token for publishing packages
 # Create at: https://www.npmjs.com/settings/YOUR_USERNAME/tokens
 NPM_TOKEN=

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -1,0 +1,33 @@
+---
+tags: [index, adr]
+---
+
+# Architectural decision records
+
+Entrypoint for all ADRs in this repository. Each record captures one architectural decision: the context it was made in, the decision itself, and its consequences. Records are immutable once accepted — a change of direction is a new ADR that supersedes the old one, so the trail of reasoning is never lost.
+
+## Format
+
+Every ADR follows the same structure:
+
+- **Frontmatter** — `status` (`proposed` | `accepted` | `superseded by [[link]]`), `date`, `tags`
+- **Context** — the forces at play: requirements, constraints, and what prompted the decision
+- **Decision** — what we chose, as bullets, stated in the active voice
+- **Consequences** — what becomes easier, what becomes harder, what we've accepted as a trade-off
+- **Open questions** — optional; unresolved threads, each linking to the (possibly not-yet-written) ADR that will resolve it
+
+Records live in `docs/adr/` and are numbered `NNNN-title.md`. Link between records with `[[wiki-links]]`; links to records that don't exist yet are deliberate — they mark decisions we know are coming.
+
+## Records
+
+- [[0001-repository-structure]] — dev environment (mise/hk/bun), no build orchestrator, monorepo layout — **accepted**
+- [[0005-style-shipping-and-package-build]] — consumer-compiles StyleX, peer-dep trio, tsc-only ESM build — **accepted**
+- [[0006-component-quality-stack]] — hand-rolled playground, committed VRT baselines via Playwright, Vitest units, oxc static gates — **accepted**
+
+## Planned
+
+- [[0002-package-architecture]] — two-tier publish shape: lockstep core + independently versioned labs
+- [[0003-urban-cli]] — the `urban` CLI: how it gathers and surfaces design-system knowledge to AI agents (see [[001-urban-cli]] PRD)
+- [[0004-release-strategy]] — intent capture, changelog assembly, and publish mechanics for npm packages and CLI binaries
+
+Conventions notes (not ADRs): [[package-anatomy]]

--- a/docs/adr/0001-repository-structure.md
+++ b/docs/adr/0001-repository-structure.md
@@ -1,0 +1,57 @@
+---
+status: accepted
+date: 2026-07-05
+tags: [adr, monorepo, tooling, dev-environment]
+---
+
+# ADR-0001 — Repository structure
+
+## Context
+
+- This repository hosts an experimental design system: stable enough to consume in real applications, structured so that experimentation is cheap and visible.
+- Predominantly TypeScript/React (React Aria + StyleX), plus standalone CLIs written in Rust or Go living in the same repository.
+- The languages are deliberately loosely coupled — JS packages never depend on CLI build output. This invariant shapes most tooling decisions below.
+- Small team (2–6), CI on GitHub Actions.
+- Prior iterations of this design system used Turborepo + changesets in a JS-only shape; this repo re-evaluates the stack from scratch.
+
+## Decision
+
+### Dev environment — the jdx stack
+
+- [mise](https://mise.jdx.dev/) is the single source of truth for toolchain versions, environment variables, and tasks.
+  - Monorepo task mode: `monorepo_root = true` at the root, Bazel-style addressing (`mise //packages/core:build`, wildcards `mise '//...:test'`).
+  - Each project directory carries its own `mise.toml`, inheriting and overriding root tools/env — CLIs pin their own Rust/Go versions without global churn.
+  - Freshness checking uses content hashing (`task.source_freshness_hash_contents = true`); every task declares `sources`/`outputs`.
+- [hk](https://hk.jdx.dev/) manages git hooks, wrapped by mise (`hk install --mise` via a mise postinstall hook) so contributors get correct tool versions without activating mise themselves.
+- [bun](https://bun.sh/) provides JS package installs and workspaces. aube remains a possible later swap — it reads and writes `bun.lock` in place, so trialling it is cheap and reversible.
+- **No build orchestrator** — no Turborepo, moon, or Nx. mise tasks orchestrate everything, across all languages.
+  - The escape hatch stays open by convention: JS packages keep canonical `package.json` scripts (`build`, `test`, `lint`) as the source of truth; mise tasks are thin wrappers around them.
+  - Revisit when PR CI wall time regularly exceeds ~10 minutes, or the workspace passes ~15–20 active nodes — at that point an orchestrator bolts onto the existing scripts.
+
+### Monorepo layout
+
+```
+apps/          deployable applications (docs site, playgrounds)
+packages/      stable published packages (core, tokens) — versioned in lockstep
+labs/          experimental packages — 0.x, independently versioned
+tools/         CLIs (Rust/Go) — standalone, never build-dependencies of JS packages
+tooling/       internal-only shared config (tsconfig base, lint presets, build presets, test setup) — never published
+docs/          this documentation brain (ADRs, specs)
+```
+
+- The `packages/` vs `labs/` boundary is the stability tier boundary, made structural — see [[0002-package-architecture]] for the versioning and graduation model.
+- `tools/` shares the repository, CI, and mise tasks, but not the JS dependency graph.
+- Apps and docs are private workspaces; they consume packages via `workspace:*` and are never published.
+
+## Consequences
+
+- One-command bootstrap: `mise install && bun install` sets up toolchains, dependencies, and hooks.
+- No content-addressed build cache, no remote cache, no affected-detection — a clean CI runner rebuilds everything, every run. Accepted at current scale; GitHub Actions caching (bun store, cargo/go caches, mise-action tool cache) covers the dependency-level costs.
+- Task conventions (`package.json` scripts + declared `sources`/`outputs`) keep the cost of adopting an orchestrator later to roughly a day, if scale ever demands it.
+- The dev environment leans heavily on one maintainer's ecosystem (jdx). Accepted: the tools are independently replaceable (hk → lefthook, bun → pnpm) and mise itself is widely adopted with full-time sponsored development.
+
+## Open questions
+
+- How the `urban` CLI gathers and surfaces design-system knowledge — manifests shipped inside packages vs alternatives → [[0003-urban-cli]]
+- Release strategy: intent capture and changelog assembly (meta plane) and npm/binary publish mechanics (publish plane) → [[0004-release-strategy]]
+- Deploy target for apps; npm scope; aube adoption timing.

--- a/docs/adr/0005-style-shipping-and-package-build.md
+++ b/docs/adr/0005-style-shipping-and-package-build.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+date: 2026-07-05
+tags: [adr, stylex, build, publishing]
+---
+
+# ADR-0005 — Style shipping and package build
+
+## Context
+
+- StyleX compiles at build time, forcing a choice for published packages: ship JS with `stylex.create` intact and let consumers compile (official StyleX guidance), or precompile to CSS + a thin runtime at publish (the pattern Meta's newly open-sourced Astryx design system ships).
+- Precompiled is zero-config for consumers — attractive for our AI-agent audience — but has no official StyleX mode, unpublished build mechanics, and known sharp edges when mixed with consumer-side compilation.
+- The theme package publishes `defineVars` tokens, where cross-package resolution still relies on `unstable_moduleResolution` — the riskiest place to deviate from official guidance.
+- Consumer-compiles is the previous iteration's proven model, and the official `@stylexjs/unplugin` now auto-discovers StyleX packages in node_modules, so consumer setup cost has dropped to one plugin line — which the `urban` CLI can teach.
+
+## Decision
+
+- **Consumer-compiles for v1**: ship transpiled JS with StyleX calls intact; `@stylexjs/stylex` is a peerDependency.
+- **Peer-dependency trio**: react, react-aria-components, @stylexjs/stylex — versions pinned repo-wide via bun catalog (single-version property; the monorepo-side defence against the singleton hazards `urban doctor` checks consumer-side).
+- **Build is `tsc` emit — no bundler**: ESM-only, per-file output (required anyway: `*.stylex.ts` modules must survive 1:1), declarations from the same tool. TypeScript 7 (the native Go compiler, RC as of July 2026): **typecheck on 7 now**; published dist emit stays on classic 6.x until 7.0 GA, then cut over after diffing the emitted `.d.ts`. Tools consuming the TS programmatic API (the ts-morph extractor) remain on the 6.x API until 7.1 stabilises it.
+- **Exports map laid down for the future**: root `.` plus per-component subpaths; the `source` export condition included from day one so Astryx-style dual-mode (precompiled CSS default + source for StyleX-native consumers) can be adopted later as an additive, non-breaking change.
+- `sideEffects` lists only `**/*.stylex.*`; knowledge artifacts (docs, examples, manifest) ship in `files`.
+- Package shape gated in CI by `publint` + `@arethetypeswrong/cli`.
+
+## Consequences
+
+- Consumers must configure one StyleX bundler plugin; installation guidance is `urban`'s job and the cost is accepted for v1.
+- No bundler means the package build is trivially cacheable and debuggable (`tsc` + copy prose + generate manifest, as mise tasks).
+- Precompiled-CSS-by-default is the recorded intended evolution — revisit when StyleX ships first-class library precompilation or the Astryx pattern stabilises; adopting it adds artifacts without breaking existing consumers.
+- Watch items: TypeScript 7.0 GA (emit cutover) and 7.1 (programmatic API for the extractor); StyleX `unstable_moduleResolution` stabilisation; facebook/stylex#1399 (test-time compilation of external packages) mitigations required in Vitest config.
+
+Related: [[package-anatomy]], [[0006-component-quality-stack]].

--- a/docs/adr/0006-component-quality-stack.md
+++ b/docs/adr/0006-component-quality-stack.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+date: 2026-07-05
+tags: [adr, testing, workbench, visual-regression, a11y]
+---
+
+# ADR-0006 — Component quality stack
+
+## Context
+
+- Working model: agents write most code autonomously; Matt's time goes to PRDs/ADRs/RFCs/schemas and **pull-request review**. Every quality gate must therefore be PR-reviewable in GitHub and agent-self-serviceable — no external dashboards, no approval SaaS.
+- Components wrap react-aria-components (accessible primitives) and are styled with StyleX (compile-time CSS), which constrains where a11y and visual properties can actually be verified: contrast and rendered styles need a real browser with compiled CSS.
+- Storybook 10's value (stories-as-tests, a11y addon, Chromatic path) was evaluated and is superseded by this model: committed screenshot baselines make Playwright's native workflow the fit, and axe rides the same suite.
+
+## Decision
+
+- **Workbench: hand-rolled `apps/playground`** (Vite) — globs `*.visual.tsx` scenes and `examples/` across packages, renders each on a stable route. It is both the dev exploration surface and the VRT render target. Published to GitHub Pages.
+- **Visual regression: Playwright `toHaveScreenshot` with baselines committed to the repo**, co-located per component (`__screenshots__/`, named by scene export).
+  - The authoring agent regenerates baselines in its PR; GitHub's native image diff is the review UI.
+  - **CI verifies reproducibility, not change**: it re-renders and fails on mismatch with committed baselines — intentional change never blocks, invisible change is impossible, doctored images can't survive.
+  - Determinism: rendering only inside the pinned Playwright container (locally via Docker and in CI), animations disabled, fixed viewport, 1x DPR, oxipng on write — wrapped as `mise …:vrt` / `vrt --update`.
+- **A11y gate: `@axe-core/playwright` in the same suite** — per scene and per example, real browser, compiled StyleX (contrast is actually checked). Per-scene exception list maintained for Adobe's documented axe false-positives on react-aria. Later layer (parked): Guidepup screen-reader smokes on flagship composites.
+- **Unit/pattern tests: Vitest 4 (jsdom project)** + testing-library + `@react-aria/test-utils` pattern testers — verifies our wrappers still satisfy ARIA pattern contracts fast, without a browser. Known pins: user-event `useFocusVisible` regression; stylex#1399 (`externalPackages` / `server.deps.inline` for token packages).
+- **Static gates, orchestrated by hk** (oxlint and oxfmt are hk builtins): TypeScript 7 typecheck (native compiler, RC today); **oxlint** 1.x — note jsx-a11y coverage is partial (28 of ~37 upstream rules), so the axe browser gate remains the a11y authority; **oxfmt** (0.x beta, Prettier-conformant output, version pinned) — changed-files on commit, `--all` in CI.
+- **Manifest extraction: custom ts-morph extractor in `tooling/`** — resolves wrapped RAC prop types via the checker; no off-the-shelf tool handles this shape (verified: react-docgen punts on intersections, react-docgen-typescript drops props under `Omit`). Fallback if extraction fights us: Astryx-style curated manifest + CI drift checks.
+
+## Consequences
+
+- No Storybook, no VRT SaaS: fewer moving parts, no vendor risk; the costs are owning a small playground app and Docker discipline for deterministic rendering.
+- Screenshot baselines add repo weight — accepted; plain git now, Git LFS documented as the escape hatch (with its CI-bandwidth caveat).
+- Examples are verified four ways with zero bespoke harness (typecheck, render, axe, screenshot) via the playground bridge; scene baselines gate regressions, example baselines are review evidence.
+- oxfmt is pre-1.0 (pinned; Prettier-conformant output keeps Prettier/Biome as drop-in fallbacks); oxlint's type-aware mode (`oxlint-tsgolint`) is late-beta — adopt once its monorepo memory behaviour proves out. The ts-morph extractor rides the TS 6.x API until TypeScript 7.1.
+- bun test is not used for component packages (no StyleX transform; axe incompatible with happy-dom) — reassess as Bun's runner matures.
+
+Related: [[package-anatomy]], [[0005-style-shipping-and-package-build]].

--- a/docs/package-anatomy.md
+++ b/docs/package-anatomy.md
@@ -1,0 +1,82 @@
+---
+tags: [conventions, packages, knowledge]
+---
+
+# Package anatomy
+
+The contract for what every publishable package contains. This anatomy is load-bearing: it is what makes packages legible to agents, to repo tooling (extractor, validators, playground, VRT), and to the `urban` CLI ([[001-urban-cli]]). Tooling globs by these conventions and never assumes beyond them.
+
+## Package layout
+
+```
+packages/react/
+├── package.json          # "urban" manifest marker; peers: react, react-aria-components, stylex
+├── mise.toml             # tasks: build, test, typecheck, vrt (sources/outputs declared)
+├── philosophy.md         # system-level decision rules                → shipped
+├── patterns/             # composition recipes that don't export code → shipped
+│   └── forms.md
+└── src/
+    └── button/           # one folder per component
+```
+
+- **theme** mirrors this minus components: token sources (`*.stylex.ts`), token docs, root philosophy for token usage.
+- **labs** mirrors the component level only — no `patterns/` (a labs experiment needing a patterns entry is a graduation smell).
+
+## Component folder anatomy
+
+```
+src/button/
+├── button.tsx            # implementation                      → shipped (dist)
+├── button.md             # authored guidance (template below)  → shipped
+├── button.test.tsx       # behavioural + pattern tests         — repo-only
+├── *.visual.tsx          # visual scenes (glob; 1+ files,      — repo-only
+│                         #   or visual/ subfolder)
+├── __screenshots__/      # committed VRT baselines             — repo-only
+├── examples/             # minimal teaching examples           → shipped
+│   └── basic.tsx
+└── index.ts
+```
+
+There is no spec file: **component specs live in the epic bead** (design-time intent; the `breakdown` flow creates the epic + child issues). Durable spec content graduates on completion — behavioural requirements → tests, usage intent → `button.md`, planned examples/scenes → their files. The spec template lives with the spec skill: overview, anatomy tree, API sketch, behaviour & states, styling plan, a11y contract, decisions & open questions, graduation checklist.
+
+## Authored guidance (`<component>.md`)
+
+The **why/when layer only**. The manifest is *what* (facts — no prop tables in prose); examples are *show* (no duplicated code). Sections:
+
+- **Purpose** — one paragraph
+- **When to use / when not** — decision guidance; wiki-link alternatives (links become graph edges)
+- **Composition** — what it sits inside, what goes inside it
+- **Prop intent** — semantics of variant/tone choices, defaults philosophy
+- **Behaviour notes** — semantics not expressible in types
+- **Anti-patterns** — the mistakes you'd correct in review
+- **Examples** — sparse pointers: each example named, one line on what it teaches
+
+Every component/prop/token/example name referenced in prose is validated against the manifest in CI.
+
+## Examples
+
+- Plain consumer code: real imports via the package's public exports, no framework idioms — the primary reader is an LLM learning usage.
+- Pedagogy over coverage: demonstrate each axis once; never enumerate matrices.
+- Verified four ways, all via the generated playground bridge: typecheck (against public exports), real-browser render, axe pass, committed screenshot.
+
+## Visual scenes (`*.visual.tsx`)
+
+- Coverage over pedagogy: exhaustive state/prop matrices (`crossProps` helper in `tooling/`), stress cases, interaction states.
+- **One export = one screenshot** — named exports are the diff unit; adding coverage never reshuffles existing baselines.
+- Screenshot naming schema: `src/<component>/__screenshots__/<file-stem>/<export-name>.png` — stable paths keep PR image diffs meaningful.
+- Overlay scenes capture at viewport level (portals escape element roots).
+- Scene baselines are the **regression gate**; example baselines are **review evidence** (expected to change with legitimate visual change).
+
+## Manifest
+
+- Generated at build (ts-morph extractor in `tooling/`); never authored, never contains prose.
+- Single discovery entrypoint: `package.json` → `"urban": { "manifest": ... }`; the manifest indexes every doc, pattern, and example with published paths.
+- Carries typed graph edges extracted from wiki-links in authored prose. Direction rule: labs may link into stable; **stable never links into labs**.
+- `schemaVersion`ed; name uniqueness across components/patterns/token-groups enforced at build.
+- Doubles as the semver oracle (see release strategy) and the validation spine for all authored content.
+
+## Definition of done (per component)
+
+spec bead accepted → implement + document + examples → tests pass → scenes + baselines committed → manifest generates; prose/example/graph validation passes → changeset filed. Every gate is PR-reviewable and agent-self-serviceable.
+
+Related: [[0001-repository-structure]], [[0005-style-shipping-and-package-build]], [[0006-component-quality-stack]], [[001-urban-cli]].

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,22 @@
+---
+tags: [index, prd]
+---
+
+# Product requirements documents
+
+Entrypoint for all PRDs in this repository. A PRD defines the problem space — what we're solving and for whom — not how to build it. It is the input to implementation planning; the *how* lands in plans and, where architecture is decided, in [[adr]] records.
+
+## Format
+
+Every PRD follows the same four sections:
+
+- **Problem** — terse; what's broken or missing, and who's affected
+- **Needle** — terse, positive; what changes in the world if we solve it
+- **Solution** — the shape of the solution from the user's perspective, free of implementation detail
+- **User stories** — extensive numbered list covering the full surface; the raw material for plan phases and acceptance criteria
+
+Records live in `docs/prds/` and are numbered `NNN-slug.md`. Link between documents with `[[wiki-links]]`.
+
+## Records
+
+- [[001-urban-cli]] — the `urban` CLI: installed-first design-system knowledge, navigable by AI agents

--- a/docs/prds/001-urban-cli.md
+++ b/docs/prds/001-urban-cli.md
@@ -1,0 +1,58 @@
+---
+title: "urban CLI — design-system knowledge for AI agents"
+---
+
+# urban CLI — design-system knowledge for AI agents
+
+## Problem
+
+AI agents building UI in consumer repositories have no reliable way to learn the design system they're using. Shipped declaration files are resolved-generic soup that agents misread; training data describes old or wrong versions; documentation sites serve humans, not tools. Any knowledge captured separately from the code drifts from what's actually installed. The result: agents misuse components, rebuild ones that already exist, violate system rules (raw values instead of tokens), and get no guidance on the system's core judgement call — when to compose existing components versus create a new focused one.
+
+## Needle
+
+An AI agent dropped into any consumer repo can, with zero prior knowledge, discover the design system and correctly apply *exactly the version installed* — composing features the system's way, and knowing when and how to create new focused components.
+
+## Solution
+
+`urban` is a fast, self-documenting command-line tool that agents (and humans) run inside consumer repositories. It answers from knowledge that ships **inside the installed design-system packages** — generated and authored at build time, carried in the package artifacts — so what it describes is definitionally what's installed. Version drift is prevented by architecture, not discipline.
+
+The surface is four commands. `urban list` orients: every component, pattern, and token group, with experimental (labs) entries flagged. `urban show <name>` answers about any of them in one composed response: exact resolved API, authored usage guidance, verified examples. `urban search <query>` returns lightweight pointers for cheap, token-conscious lookup. `urban doctor` explains itself: what was resolved from where, which versions, whether the CLI and packages understand each other, and whether known hazards (duplicate accessibility-library copies, mismatched theme/react versions) are present.
+
+Every response is a hypermedia document: it ends with executable pointers to related knowledge — the patterns a component appears in, the tokens it consumes, the philosophy that governs it — so the agent navigates the knowledge graph by following affordances, never by guessing. Errors route the same way (unknown names return nearest matches as runnable commands). The tool is its own onboarding.
+
+The knowledge itself has four kinds: generated reference (exact API, always correct because it's derived from source at build time), authored how-to and composition guidance, authored system philosophy and decision rules, and verified examples. Authored knowledge is validated against the generated reference continuously, so prose that references a renamed prop fails the design system's build — shipped guidance cannot rot. Answers resolve relative to where the caller stands (correct per-app versions in monorepos, with an explicit override), experimental knowledge is never linked from stable knowledge, and structured output is available everywhere for programmatic use.
+
+v1 is read-only knowledge plus doctor, installed via mise or GitHub Releases, versioned independently of the design system packages. Explicitly out of v1: checks against consumer code, project metrics, code generation, MCP serving, npm-based installation, and network-fetched knowledge (no-project and cross-version queries) — the architecture leaves room for all of these. The discovery mechanism is deliberately open so that, later, a consumer's own components can join the queryable graph by adopting the same knowledge anatomy.
+
+## User Stories
+
+**As an AI agent…**
+
+1. …I want to run `urban list` and see all components, patterns, and token groups with stability flags, so that I can orient in the design system with zero prior knowledge.
+2. …I want `urban show <component>` to return resolved API, usage guidance, and working examples in one response, so that I can build correct UI without interpreting declaration files.
+3. …I want `urban show <pattern>` to explain how components compose into a feature, so that I build features the system's way instead of inventing my own composition.
+4. …I want to query the system's decision rules, so that I know when to compose existing components versus create a new focused one — and how to create it properly.
+5. …I want token knowledge (`urban show spacing`), so that I style with tokens instead of raw values.
+6. …I want every response to end with executable pointers to related knowledge, so that I can walk the graph without guessing names or commands.
+7. …I want `urban search <query>` to return pointers rather than full content, so that I spend context tokens only on what I choose to fetch.
+8. …I want unknown or misspelled names to return nearest matches as runnable commands, so that I self-correct in one step.
+9. …I want answers to describe exactly the versions installed where I'm working — cwd-relative in monorepos, with a `--project` override — so that I never follow guidance for an API that isn't there.
+10. …I want experimental (labs) entries flagged and never linked from stable knowledge, so that I adopt experiments deliberately, not accidentally.
+11. …I want `--json` on every command, so that I can consume answers programmatically when prose isn't what I need.
+
+**As a developer in a consumer repo…**
+
+12. …I want to install `urban` with one line via mise (or a GitHub Release), so that setup fits the toolchain I already use.
+13. …I want `urban doctor` to show the full resolution trace — where it looked, what it found, versions and compatibility — so that I can debug why answers look wrong.
+14. …I want doctor to detect duplicate accessibility-library copies and theme/react version mismatches, so that silent composition breakage is caught early.
+15. …I want doctor to tell me when my installed design system is too old or too new for my CLI version, with the remedy, so that compatibility issues are explicit.
+16. …I want meaningful exit codes, so that doctor can gate CI on a healthy installation.
+
+**As a design-system maintainer…**
+
+17. …I want component docs and examples co-located with component source and shipped in the package, so that knowledge versions with the code and cannot drift from it.
+18. …I want the machine-readable reference generated from source at build time, so that the API the CLI reports is always exact.
+19. …I want CI to reject authored prose that references nonexistent components, props, or tokens — and examples that don't typecheck — so that shipped guidance can't rot.
+20. …I want cross-references in authored prose to become graph edges automatically, so that the navigable graph assembles from natural writing rather than bookkeeping.
+21. …I want the CLI versioned independently of the packages, so that engine improvements ship without design-system releases and vice versa.
+22. …I want labs components to carry the same (component-level) knowledge anatomy as stable ones, so that graduation is a move, not a rewrite, and "what's experimental right now?" is answerable.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,29 @@
 {
   "version": 1,
   "skills": {
+    "breakdown": {
+      "source": "mattstyles/skills",
+      "sourceType": "github",
+      "skillPath": "breakdown/SKILL.md",
+      "computedHash": "aed3c1e6e7847902f4bcc79d68a4f9033e55adcf24ee4d65c540c5b6b7cbf629"
+    },
     "gorilla": {
       "source": "mattstyles/skills",
       "sourceType": "github",
       "skillPath": "gorilla/SKILL.md",
       "computedHash": "ba7418ed286b392c0a0b8a64b7ddd23be52371ec387b9981490cd5f6f54e9ff3"
+    },
+    "plan": {
+      "source": "mattstyles/skills",
+      "sourceType": "github",
+      "skillPath": "plan/SKILL.md",
+      "computedHash": "db3babb0b941c9ecf8710dd9fdbf975b48c8ed7fb8f3e9204ee39f5aebb7d5ce"
+    },
+    "prd": {
+      "source": "mattstyles/skills",
+      "sourceType": "github",
+      "skillPath": "prd/SKILL.md",
+      "computedHash": "024e053c6648e50419a83802e0c4ae4b20dd8554c6350815678b4ae1bc79bb69"
     },
     "react-aria": {
       "source": "react-aria.adobe.com",


### PR DESCRIPTION

## Summary

First working PR of the 0.10.0 soft reset: establishes the docs brain (Obsidian-style, wiki-linked) and records the foundational architecture decisions for the rebuilt design system, plus the planning skills (breakdown, plan, prd) used to produce them.

## Docs added

- **`docs/adr.md`** — ADR index: format definition, immutability rule, records + planned stubs
- **ADR-0001 — repository structure**: jdx dev environment (mise tasks/env/toolchains, hk hooks, bun), no build orchestrator (mise tasks only, escape hatch preserved), monorepo layout `apps / packages / labs / tools / tooling / docs`
- **ADR-0005 — style shipping & package build**: consumer-compiles StyleX with peer-dep trio (react, react-aria-components, stylex — catalog-pinned); tsc-only ESM per-file build (typecheck on TS 7 RC, emit on 6.x until GA); exports map lays down the `source` condition so Astryx-style precompiled CSS stays an additive evolution
- **ADR-0006 — component quality stack**: hand-rolled `apps/playground` (no Storybook); Playwright VRT with **committed screenshot baselines** — GitHub image diff is the review UI, CI re-renders to verify reproducibility; axe gate in the same suite; Vitest 4 unit/pattern layer; oxlint + oxfmt + tsc via hk; custom ts-morph manifest extractor
- **`docs/prd.md` + PRD-001 — urban CLI**: installed-first design-system knowledge for AI agents — four-command surface (`list` / `show` / `search` / `doctor`), hypermedia responses with executable pointers, knowledge shipped inside packages so drift is impossible by construction
- **`docs/package-anatomy.md`** — the per-package/per-component contract: shipped vs repo-only artifacts, authored-guidance template, examples (pedagogy) vs visual scenes (coverage), manifest as single discovery entrypoint, definition of done

## Notes

- Specs live in epic beads (no `.spec.md` files); durable content graduates into docs/tests/scenes on completion
- Watch items recorded in the ADRs: TypeScript 7.0 GA emit cutover (7.1 for the extractor API), StyleX `unstable_moduleResolution`, oxfmt pre-1.0 pin
- ADR-0002 (package architecture), 0003 (urban CLI ADR), 0004 (release strategy) are planned stubs — decided or in-flight in the working sessions, to be written next

🤖 Generated with [Claude Code](https://claude.com/claude-code)