### PR TITLE
Phase 1: Bootstrap — the jdx stack and repo skeleton (urban-ui-aad)

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -31,3 +31,10 @@ if command -v bd >/dev/null 2>&1; then
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.1.0 ---
+
+
+# --- urban-ui: chain to hk ---
+# core.hooksPath points at .beads/hooks, bypassing hk's install in .git/hooks —
+# so run hk here, after the beads section, mirroring hk's generated hook.
+test "${HK:-1}" = "0" || exec mise x -- hk run pre-commit --from-hook "$@"
+

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,1 @@
+{"id":"int-40e7d1f912aca631a7a7d52e531aa9a5","kind":"field_change","created_at":"2026-07-06T20:34:44.71693Z","actor":"Matt Styles","issue_id":"urban-ui-aad","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Completed — PR https://github.com/mattstyles/urban-ui/pull/26"}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Gates — oxlint, oxfmt, typecheck (all files)
+        run: hk check --all
+
+      - name: Build all workspaces
+        run: mise run '//...:build'

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 *.db
 .beads-credential-key
 .beads/proxieddb/
+.playwright-mcp/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json"
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./internal/config/oxlint.base.json"],
+  "ignorePatterns": ["**/dist/**", "**/node_modules/**"]
+}

--- a/.playwright-mcp/console-2026-07-06T20-43-42-091Z.log
+++ b/.playwright-mcp/console-2026-07-06T20-43-42-091Z.log
@@ -1,1 +1,0 @@
-[      86ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:4173/favicon.ico:0

--- a/.playwright-mcp/console-2026-07-06T20-43-42-091Z.log
+++ b/.playwright-mcp/console-2026-07-06T20-43-42-091Z.log
@@ -1,0 +1,1 @@
+[      86ms] [ERROR] Failed to load resource: the server responded with a status of 404 (Not Found) @ http://localhost:4173/favicon.ico:0

--- a/.playwright-mcp/page-2026-07-06T20-43-42-181Z.yml
+++ b/.playwright-mcp/page-2026-07-06T20-43-42-181Z.yml
@@ -1,0 +1,3 @@
+- main [ref=e3]:
+  - heading "Workbench" [level=1] [ref=e4]
+  - button "Button" [ref=e5]

--- a/.playwright-mcp/page-2026-07-06T20-43-42-181Z.yml
+++ b/.playwright-mcp/page-2026-07-06T20-43-42-181Z.yml
@@ -1,3 +1,0 @@
-- main [ref=e3]:
-  - heading "Workbench" [level=1] [ref=e4]
-  - button "Button" [ref=e5]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,13 +69,13 @@ Repository documentation is a wiki-linked graph under `docs/`. Enter through the
 
 ## Build & Test
 
-_Add your build and test commands here_
-
 ```bash
-# Example:
-# npm install
-# npm test
+mise install && bun install   # bootstrap: pinned toolchains, workspace deps, git hooks
+mise run '//...:build'        # run a task across all workspaces (also :lint, :typecheck)
+hk check --all                # all gates (oxlint, oxfmt, typecheck) against all files — CI parity
 ```
+
+Canonical `build`/`lint`/`typecheck` scripts live in each package's `package.json`; mise tasks are thin wrappers with declared `sources`/`outputs` (content-hash freshness). See [[0001-repository-structure]].
 
 ## Architecture Overview
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,105 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "urban-ui",
+      "devDependencies": {
+        "oxfmt": "0.57.0",
+        "oxlint": "1.72.0",
+        "typescript": "6.0.3",
+      },
+    },
+    "internal/config": {
+      "name": "@urban-ui/config",
+      "version": "0.0.0",
+    },
+  },
+  "packages": {
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.57.0", "", { "os": "android", "cpu": "arm" }, "sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig=="],
+
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.57.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g=="],
+
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.57.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg=="],
+
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.57.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A=="],
+
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.57.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ=="],
+
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A=="],
+
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.57.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ=="],
+
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg=="],
+
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.57.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA=="],
+
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.57.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ=="],
+
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA=="],
+
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.57.0", "", { "os": "linux", "cpu": "none" }, "sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ=="],
+
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.57.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA=="],
+
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg=="],
+
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.57.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg=="],
+
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.57.0", "", { "os": "none", "cpu": "arm64" }, "sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ=="],
+
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.57.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g=="],
+
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.57.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg=="],
+
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.57.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.72.0", "", { "os": "android", "cpu": "arm" }, "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.72.0", "", { "os": "android", "cpu": "arm64" }, "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.72.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.72.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.72.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.72.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.72.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.72.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.72.0", "", { "os": "linux", "cpu": "none" }, "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.72.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.72.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.72.0", "", { "os": "none", "cpu": "arm64" }, "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.72.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.72.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.72.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="],
+
+    "@urban-ui/config": ["@urban-ui/config@workspace:internal/config"],
+
+    "oxfmt": ["oxfmt@0.57.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.57.0", "@oxfmt/binding-android-arm64": "0.57.0", "@oxfmt/binding-darwin-arm64": "0.57.0", "@oxfmt/binding-darwin-x64": "0.57.0", "@oxfmt/binding-freebsd-x64": "0.57.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.57.0", "@oxfmt/binding-linux-arm-musleabihf": "0.57.0", "@oxfmt/binding-linux-arm64-gnu": "0.57.0", "@oxfmt/binding-linux-arm64-musl": "0.57.0", "@oxfmt/binding-linux-ppc64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-gnu": "0.57.0", "@oxfmt/binding-linux-riscv64-musl": "0.57.0", "@oxfmt/binding-linux-s390x-gnu": "0.57.0", "@oxfmt/binding-linux-x64-gnu": "0.57.0", "@oxfmt/binding-linux-x64-musl": "0.57.0", "@oxfmt/binding-openharmony-arm64": "0.57.0", "@oxfmt/binding-win32-arm64-msvc": "0.57.0", "@oxfmt/binding-win32-ia32-msvc": "0.57.0", "@oxfmt/binding-win32-x64-msvc": "0.57.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA=="],
+
+    "oxlint": ["oxlint@1.72.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.72.0", "@oxlint/binding-android-arm64": "1.72.0", "@oxlint/binding-darwin-arm64": "1.72.0", "@oxlint/binding-darwin-x64": "1.72.0", "@oxlint/binding-freebsd-x64": "1.72.0", "@oxlint/binding-linux-arm-gnueabihf": "1.72.0", "@oxlint/binding-linux-arm-musleabihf": "1.72.0", "@oxlint/binding-linux-arm64-gnu": "1.72.0", "@oxlint/binding-linux-arm64-musl": "1.72.0", "@oxlint/binding-linux-ppc64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-gnu": "1.72.0", "@oxlint/binding-linux-riscv64-musl": "1.72.0", "@oxlint/binding-linux-s390x-gnu": "1.72.0", "@oxlint/binding-linux-x64-gnu": "1.72.0", "@oxlint/binding-linux-x64-musl": "1.72.0", "@oxlint/binding-openharmony-arm64": "1.72.0", "@oxlint/binding-win32-arm64-msvc": "1.72.0", "@oxlint/binding-win32-ia32-msvc": "1.72.0", "@oxlint/binding-win32-x64-msvc": "1.72.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA=="],
+
+    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+  }
+}

--- a/docs/adr/0002-package-architecture.md
+++ b/docs/adr/0002-package-architecture.md
@@ -52,4 +52,4 @@ Two tiers, three published npm packages. (The `urban` CLI also lives under `pack
 
 ## Open questions
 
-- npm scope and package naming.
+- npm scope and package naming. — *Resolved in [[001-repo-foundation]] Phase 1: `@urban-ui/react`, `@urban-ui/theme`, `@urban-ui/labs`; the `@urban-ui` scope is already owned (prior-iteration packages live there).*

--- a/docs/plans/001-repo-foundation.md
+++ b/docs/plans/001-repo-foundation.md
@@ -49,7 +49,7 @@ The ADRs are the substrate; this plan implements without re-litigating. Plan-lev
 
 ## Phases
 
-### Phase 1: Bootstrap — the jdx stack and repo skeleton — urban-ui-aad
+### ✅ Phase 1: Bootstrap — the jdx stack and repo skeleton — urban-ui-aad — [PR #26](https://github.com/mattstyles/urban-ui/pull/26)
 
 Delivers: a clone-to-committing developer/agent experience — toolchain, layout, hooks, CI skeleton all live.
 Covers: AC 1, 2 (fully proven once real packages exist in Phase 2)

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,34 @@
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+
+// Gates per ADR-0006: oxlint + oxfmt on changed files, whole-workspace typecheck.
+// `hk check --all` runs the same steps against every file — CI parity.
+local linters = new Mapping<String, Step> {
+    ["oxfmt"] {
+        glob = List("*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs")
+        check = "bunx oxfmt --check {{files}}"
+        fix = "bunx oxfmt {{files}}"
+    }
+    ["oxlint"] {
+        glob = List("*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs")
+        check = "bunx oxlint {{files}}"
+        fix = "bunx oxlint --fix {{files}}"
+    }
+    ["typecheck"] {
+        glob = List("*.ts", "*.tsx")
+        check = "mise run '//...:typecheck'"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+    ["fix"] {
+        steps = linters
+    }
+}

--- a/internal/config/mise.toml
+++ b/internal/config/mise.toml
@@ -1,0 +1,13 @@
+[tasks.build]
+description = "Compile to dist/ via tsc"
+run = "bun run build"
+sources = ["src/**/*", "tsconfig.json", "tsconfig.base.json", "package.json"]
+outputs = ["dist/**/*"]
+
+[tasks.typecheck]
+description = "Typecheck without emitting"
+run = "bun run typecheck"
+
+[tasks.lint]
+description = "oxlint over package sources"
+run = "bun run lint"

--- a/internal/config/oxlint.base.json
+++ b/internal/config/oxlint.base.json
@@ -1,0 +1,8 @@
+{
+  "plugins": ["typescript", "import", "unicorn", "jsx-a11y"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn"
+  },
+  "rules": {}
+}

--- a/internal/config/package.json
+++ b/internal/config/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@urban-ui/config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Internal shared config — tsconfig base and lint presets. Never published.",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./tsconfig.base.json": "./tsconfig.base.json",
+    "./oxlint.base.json": "./oxlint.base.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint src"
+  }
+}

--- a/internal/config/src/index.ts
+++ b/internal/config/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Placeholder module. This package carries the shared tsconfig base and lint
+ * presets; this module exists so the build/typecheck/lint pipeline and mise
+ * task addressing have something real to run against until internal scripts
+ * (extractor, release tooling) land here.
+ */
+export const packageName = "@urban-ui/config";

--- a/internal/config/tsconfig.base.json
+++ b/internal/config/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  }
+}

--- a/internal/config/tsconfig.base.json
+++ b/internal/config/tsconfig.base.json
@@ -1,18 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
+  // Shaped by https://www.totaltypescript.com/tsconfig-cheat-sheet.
+  // Module strategy is deliberately absent: tsc-transpiled packages set
+  // "module": "nodenext" (+ declaration/sourceMap); bundler-built apps set
+  // "module": "preserve" + "noEmit".
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
+    /* Base options */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    /* Strictness */
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "verbatimModuleSyntax": true,
-    "isolatedModules": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "skipLibCheck": true
+    "noImplicitOverride": true,
+
+    /* DOM runtime + React */
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "jsx": "react-jsx"
   }
 }

--- a/internal/config/tsconfig.json
+++ b/internal/config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/internal/config/tsconfig.json
+++ b/internal/config/tsconfig.json
@@ -1,8 +1,12 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "module": "nodenext",
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
   },
   "include": ["src"]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,17 @@
+monorepo_root = true
+
+[monorepo]
+# "labs" joins config_roots (and bun workspaces) when the labs package lands in Phase 7
+config_roots = ["apps/*", "packages/*", "internal/*"]
+
+[settings]
+task.source_freshness_hash_contents = true
+
 [tools]
+bun = "1.3.14"
+hk = "1.49.0"
 "github:gastownhall/beads" = "1.1.0"
 "npm:@kitlangton/stack" = "0.4.2"
+
+[hooks]
+postinstall = "hk install --mise"

--- a/package.json
+++ b/package.json
@@ -5,11 +5,19 @@
   "private": true,
   "license": "MIT",
   "author": "Matt Styles",
-  "workspaces": [],
+  "workspaces": [
+    "apps/*",
+    "packages/*",
+    "internal/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mattstyles/urban-ui.git"
   },
   "scripts": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "oxfmt": "0.57.0",
+    "oxlint": "1.72.0",
+    "typescript": "6.0.3"
+  }
 }


### PR DESCRIPTION

## Summary
Stands up the clone-to-committing developer/agent experience per [docs/plans/001-repo-foundation.md](docs/plans/001-repo-foundation.md) Phase 1: mise monorepo task mode, bun workspaces, hk-managed git hooks, and the CI skeleton — realizing ADR-0001.

## Changes
- Root `mise.toml`: `monorepo_root = true`, explicit `config_roots`, content-hash task freshness, pinned bun 1.3.14 + hk 1.49.0, and a postinstall hook running `hk install --mise` (one-command bootstrap: `mise install && bun install`)
- Directory skeleton: `apps/`, `packages/`, `labs/`, `internal/` with bun workspaces wired at the root (`labs` joins workspaces/config_roots in Phase 7 when its package lands)
- `internal/config` (`@urban-ui/config`, private): shared `tsconfig.base.json` + `oxlint.base.json` presets, plus a placeholder built module proving Bazel-style addressing (`mise run '//internal/config:build'`), wildcard runs (`//...:build`), and content-hash freshness (second run skips)
- `hk.pkl`: pre-commit runs oxlint + oxfmt on changed files and whole-workspace typecheck; `check`/`fix` hooks give CI parity via `hk check --all`
- Beads/hk hook coexistence: beads owns `core.hooksPath` (`.beads/hooks`), so the tracked beads pre-commit chains to hk after its managed section
- CI skeleton (`.github/workflows/ci.yml`): mise-action → `bun install --frozen-lockfile` → `hk check --all` → `mise run '//...:build'`
- devDependencies: typescript 6.0.3, oxlint 1.72.0, oxfmt 0.57.0 (+ `.oxlintrc.json` / `.oxfmtrc.json` at root)
- ADR-0002 open question annotated resolved: `@urban-ui` scope already owned (prior-iteration packages); names `@urban-ui/react`/`theme`/`labs`
- AGENTS.md Build & Test section filled in

## Testing
- `mise install && bun install` from clean state installs toolchains, deps, and hooks (postinstall verified)
- `mise run '//...:build'` twice: first compiles, second reports "sources up-to-date, skipping" (content-hash freshness)
- `mise run '//...:lint'` / `//...:typecheck` green; `hk check --all` green
- A real commit on this branch triggered the chained beads→hk pre-commit: oxlint + oxfmt (changed files) + typecheck all ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#26** 👈 current
2. #27
<!-- stack:links:end -->