### PR TITLE
:books: Add workflow section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ hk check --all                # all gates (oxlint, oxfmt, typecheck) against all
 
 Canonical `build`/`lint`/`typecheck` scripts live in each package's `package.json`; mise tasks are thin wrappers with declared `sources`/`outputs` (content-hash freshness). See [[0001-repository-structure]].
 
+## Workflow
+
+- Never push to `main` — work on branches and merge via pull requests.
+- For segmented work (e.g. multi-phase plans), use `stack` to split it across a stack of PRs, one per segment. See the `stack` skill.
+
 ## Architecture Overview
 
 _Add a brief overview of your project architecture_


### PR DESCRIPTION

## Summary
Adds a terse Workflow section to AGENTS.md documenting the branching and PR conventions for agents.

## Changes
- Never push to `main` — branches and pull requests only
- Use `stack` to split segmented work (e.g. multi-phase plans) across a stack of PRs

## Testing
No testing required — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)