### PR TITLE
Fix dev StyleX token resolution; tier the VRT TOC (urban-ui-v9o)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -12,3 +12,4 @@
 {"id":"int-2222998a590c364706bddc5307396cd0","kind":"field_change","created_at":"2026-07-07T06:39:47.174611Z","actor":"Matt Styles","issue_id":"urban-ui-26d","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-122c501bc0166356778ff448bae8cd4e","kind":"field_change","created_at":"2026-07-07T06:48:15.348725Z","actor":"Matt Styles","issue_id":"urban-ui-pr1","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-38772acfeb0cc881e7c283fa6e5e194f","kind":"field_change","created_at":"2026-07-07T06:53:59.493307Z","actor":"Matt Styles","issue_id":"urban-ui-r59","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-35426c7141a4d113f911c0a106f41cbe","kind":"field_change","created_at":"2026-07-07T07:13:07.805813Z","actor":"Matt Styles","issue_id":"urban-ui-v9o","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}

--- a/apps/vrt/src/app.tsx
+++ b/apps/vrt/src/app.tsx
@@ -13,7 +13,17 @@ const styles = stylex.create({
   index: {
     display: "flex",
     flexDirection: "column",
+    gap: space.lg,
+  },
+  tier: {
+    display: "flex",
+    flexDirection: "column",
     gap: space.md,
+  },
+  group: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.sm,
   },
   link: {
     color: colors.accent,
@@ -54,19 +64,58 @@ function currentRoute(): string {
   return hash === "" ? "/" : hash;
 }
 
+// TOC: stability tier first (labs is the experimental package, everything
+// else rides the stable core train), then one group per component.
+const TIERS = ["Stable", "Labs"] as const;
+
+function tierOf(entry: RenderableEntry): (typeof TIERS)[number] {
+  return entry.pkg === "labs" ? "Labs" : "Stable";
+}
+
 function Index() {
+  const groups = new Map<string, Map<string, RenderableEntry[]>>(
+    TIERS.map((tier) => [tier, new Map()]),
+  );
+  for (const entry of renderables) {
+    const components = groups.get(tierOf(entry));
+    if (components === undefined) {
+      continue;
+    }
+    // Labs is one package, so the pkg prefix is noise under its tier heading;
+    // stable components keep it (react/button) since the tier spans packages.
+    const key = entry.pkg === "labs" ? entry.component : `${entry.pkg}/${entry.component}`;
+    const group = components.get(key) ?? [];
+    group.push(entry);
+    components.set(key, group);
+  }
   return (
     <main {...stylex.props(styles.page, styles.index)}>
       <h1>Urban UI VRT scenes</h1>
-      <ul>
-        {renderables.map((entry) => (
-          <li key={entry.route}>
-            <a href={`#${entry.route}`} {...stylex.props(styles.link)}>
-              {entry.kind}: {entry.pkg}/{entry.component}/{entry.fileStem}/{entry.exportName}
-            </a>
-          </li>
-        ))}
-      </ul>
+      {TIERS.map((tier) => {
+        const components = groups.get(tier);
+        if (components === undefined || components.size === 0) {
+          return null;
+        }
+        return (
+          <section key={tier} {...stylex.props(styles.tier)}>
+            <h2>{tier}</h2>
+            {[...components.entries()].map(([key, entries]) => (
+              <section key={key} {...stylex.props(styles.group)}>
+                <h3>{key}</h3>
+                <ul>
+                  {entries.map((entry) => (
+                    <li key={entry.route}>
+                      <a href={`#${entry.route}`} {...stylex.props(styles.link)}>
+                        {entry.kind}: {entry.fileStem}/{entry.exportName}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </section>
+        );
+      })}
     </main>
   );
 }

--- a/apps/vrt/vite.config.ts
+++ b/apps/vrt/vite.config.ts
@@ -17,14 +17,6 @@ export default defineConfig(({ command }) => ({
       // Readable debug class names while developing.
       dev: command === "serve",
       devMode: "full",
-      // Dev serves package *sources* (aliases below), so the StyleX compiler
-      // must resolve token imports to the same source files — it has its own
-      // resolver that would otherwise walk package exports to dist.
-      ...(command === "serve" && {
-        aliases: {
-          "@urban-ui/theme/tokens.stylex": [pkg("theme", "src", "tokens.stylex.ts")],
-        },
-      }),
     }),
     react(),
   ],
@@ -43,7 +35,13 @@ export default defineConfig(({ command }) => ({
               replacement: pkg("theme", "src", "index.ts"),
             },
             {
-              find: /^@urban-ui\/theme\/(.+)$/,
+              // tokens.stylex is deliberately NOT aliased: StyleX hashes var
+              // names from the defining module's identity, and the compiler
+              // resolves token imports in *other* files through package
+              // exports to dist. Serving the source tokens module would
+              // define source-hashed vars that no compiled rule references —
+              // classes apply but every var() is undefined (unstyled page).
+              find: /^@urban-ui\/theme\/(?!tokens\.stylex$)(.+)$/,
               replacement: pkg("theme", "src", "$1.ts"),
             },
             {

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -20,14 +20,6 @@ export default defineConfig(({ command }) => ({
       // Readable debug class names while developing.
       dev: command === "serve",
       devMode: "full",
-      // Dev serves package *sources* (aliases below), so the StyleX compiler
-      // must resolve token imports to the same source files — it has its own
-      // resolver that would otherwise walk package exports to dist.
-      ...(command === "serve" && {
-        aliases: {
-          "@urban-ui/theme/tokens.stylex": [pkg("theme", "src", "tokens.stylex.ts")],
-        },
-      }),
     }),
     react(),
   ],
@@ -46,7 +38,13 @@ export default defineConfig(({ command }) => ({
               replacement: pkg("theme", "src", "index.ts"),
             },
             {
-              find: /^@urban-ui\/theme\/(.+)$/,
+              // tokens.stylex is deliberately NOT aliased: StyleX hashes var
+              // names from the defining module's identity, and the compiler
+              // resolves token imports in *other* files through package
+              // exports to dist. Serving the source tokens module would
+              // define source-hashed vars that no compiled rule references —
+              // classes apply but every var() is undefined (unstyled page).
+              find: /^@urban-ui\/theme\/(?!tokens\.stylex$)(.+)$/,
               replacement: pkg("theme", "src", "$1.ts"),
             },
             {


### PR DESCRIPTION

## Summary
Two VRT-app fixes: dev mode rendered completely unstyled (in the workbench too — same bug), and the index TOC was a flat list. Dev styling is fixed at the root cause, and the TOC now groups by stability tier, then component.

## Changes
- **Dev styling:** StyleX hashes CSS var names from the defining module's identity. In dev, the Vite alias served the *source* tokens module (defining source-hashed vars) while the StyleX compiler resolved token imports in every other file through package exports to *dist* (referencing dist-hashed vars) — classes applied but every `var()` was undefined, so pages rendered unstyled. Fix: leave `@urban-ui/theme/tokens.stylex` unaliased in dev so definitions and references share the dist identity, and drop the plugin `aliases` block that demonstrably didn't take effect. Applied to both `apps/vrt` and `apps/workbench` (same bug, pre-existing there)
- **TOC:** VRT index groups renderables under `Stable` / `Labs` tier headings, then one section per component (`react/button`; labs components drop the redundant pkg prefix)

## Testing
- Reproduced the bug in both dev servers (atomic classes present, 8 referenced token vars undefined); after the fix, computed styles resolve (button `rgb(79,70,229)`, page white) in both apps, verified in a real browser
- TOC structure verified via accessibility snapshot: Stable → react/button, Labs → toggle-button
- Containerized VRT passes 5/5 against unchanged baselines (the config change is dev-only; prod resolution is untouched); typecheck, lint, `hk check --all` pass

Stacked on #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #38
2. #39
3. #40
4. **#42** 👈 current
<!-- stack:links:end -->