### PR TITLE
:memo: Add conventions knowledge record, seeded with categorise-by-intent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,4 +88,4 @@ _Add a brief overview of your project architecture_
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+Repo-wide conventions live in [docs/knowledge/conventions.md](docs/knowledge/conventions.md) — read it before structuring new code or packages.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -18,6 +18,7 @@ Records live in `docs/knowledge/`.
 
 ## Records
 
+- [[conventions]] — flat list of repo-wide rules (categorise by intent, …)
 - [[package-anatomy]] — the contract for what every publishable package contains: layout, component anatomy, authored-guidance template, manifest, definition of done
 - [[release-runbook]] — how a train departs: intent → assembly → merge-as-departure, rehearsal commands, the first-release decision, previews
 - [[watch-items]] — living register of external events, pins, and revisit triggers committed to in ADRs

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -7,3 +7,5 @@ tags: [knowledge, conventions]
 Repo-wide conventions that don't belong to any single package or record. Flat list; each entry is one rule, with a clarifying sentence only where the rule alone could be misread.
 
 - **Categorise by intent, not by kind.** No utility buckets (`utils/`, `helpers/`, `tooling/`) — a module or package is named for the question it answers (`internal/workspace`: "what packages exist here?"), never for the shape of the code inside it.
+- **Prefer single-arity functions.** A function that needs more than one value takes a single object with named fields, not a parameter list.
+- **Colocate tests with implementation.** `src/thing.test.ts` sits beside `src/thing.ts` — no separate `test/` trees for test files (fixture directories may still stand alone).

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -1,0 +1,9 @@
+---
+tags: [knowledge, conventions]
+---
+
+# Conventions
+
+Repo-wide conventions that don't belong to any single package or record. Flat list; each entry is one rule, with a clarifying sentence only where the rule alone could be misread.
+
+- **Categorise by intent, not by kind.** No utility buckets (`utils/`, `helpers/`, `tooling/`) — a module or package is named for the question it answers (`internal/workspace`: "what packages exist here?"), never for the shape of the code inside it.


### PR DESCRIPTION
Adds `docs/knowledge/conventions.md` — a flat-list knowledge record for repo-wide rules, seeded with one entry: **categorise by intent, not by kind** (no utility buckets; modules are named for the question they answer, e.g. the upcoming `internal/workspace`).

- Indexed as `[[conventions]]` in `docs/knowledge.md`
- `AGENTS.md` "Conventions & Patterns" placeholder now points at the record (CLAUDE.md inherits via symlink)

Docs-only; no intent file needed.