### PR TITLE
:fire: Remove dead code and stale comments

### DIFF
--- a/internal/config/src/index.ts
+++ b/internal/config/src/index.ts
@@ -1,7 +1,7 @@
 /**
- * Placeholder module. This package carries the shared tsconfig base and lint
- * presets; this module exists so the build/typecheck/lint pipeline and mise
- * task addressing have something real to run against until internal scripts
- * (extractor, release tooling) land here.
+ * Placeholder module. This package holds shared configuration — the tsconfig
+ * base and lint presets — and only configuration; this module exists so the
+ * build/typecheck/lint pipeline and mise task addressing have something real
+ * to run against.
  */
 export const packageName = "@urban-ui/config";

--- a/internal/engram/src/generate.ts
+++ b/internal/engram/src/generate.ts
@@ -44,8 +44,6 @@ interface AuthoredDoc {
   context: DocContext;
   /** Absolute path. */
   absolutePath: string;
-  /** Extra names this doc may reference beyond the global universe. */
-  localNames: Set<string>;
 }
 
 function buildManifest(
@@ -101,10 +99,6 @@ function authoredDocsFor(
     if (!component.doc) {
       continue;
     }
-    const localNames = new Set<string>();
-    for (const prop of component.props) {
-      localNames.add(prop.name);
-    }
     docs.push({
       context: {
         file: path.relative(repoRoot, path.join(pkg.dir, component.doc)),
@@ -112,7 +106,6 @@ function authoredDocsFor(
         tier: pkg.tier,
       },
       absolutePath: path.join(pkg.dir, component.doc),
-      localNames,
     });
   }
   for (const pattern of manifest.patterns) {
@@ -123,7 +116,6 @@ function authoredDocsFor(
         tier: pkg.tier,
       },
       absolutePath: path.join(pkg.dir, pattern.path),
-      localNames: new Set(),
     });
   }
   for (const doc of manifest.docs) {
@@ -134,7 +126,6 @@ function authoredDocsFor(
         tier: pkg.tier,
       },
       absolutePath: path.join(pkg.dir, doc.path),
-      localNames: new Set(),
     });
   }
   return docs;
@@ -204,8 +195,9 @@ export function runExtractor(repoRoot: string, mode: Mode): RunResult {
       const resolved = resolveWikiLinks(doc.context, prose.wikiLinks, registry);
       edges.push(...resolved.edges);
       issues.push(...resolved.issues);
-      const universe = new Set([...globalUniverse, ...doc.localNames]);
-      issues.push(...validateNameSpans(doc.context, prose.nameSpans, universe, prose.ignored));
+      issues.push(
+        ...validateNameSpans(doc.context, prose.nameSpans, globalUniverse, prose.ignored),
+      );
     }
     manifest.graph = edges.sort((a, b) => `${a.from} ${a.to}`.localeCompare(`${b.from} ${b.to}`));
   }


### PR DESCRIPTION

Three confirmed-dead items from bead **urban-ui-cqk**:

1. **Delete `packages/labs/.gitkeep`** — labs has real content now (`toggle-button`), so the placeholder is obsolete.
2. **Remove the redundant `localNames` machinery in `internal/engram`** — `AuthoredDoc.localNames` was seeded in `generate.ts` with the component's own prop names and unioned into the name universe, but `manifestNameUniverse` (`validate.ts`) already adds every prop name of every component to the global universe, so `localNames` was always a subset. Deleted the field from the `AuthoredDoc` type, the seeding loop, and the union. No tests referenced it.
3. **Rewrite the stale charter comment in `internal/config/src/index.ts`** — it claimed the package exists "until internal scripts (extractor, release tooling) land here"; those landed as `internal/engram` and `internal/exfil` instead. The comment now states the actual charter: shared configuration (tsconfig base, lint presets) and only configuration.

## Validation

- `bun run test` in `internal/engram`: 21 pass, 0 fail
- `hk check --all`: oxlint, oxfmt, typecheck all green
- `mise run manifest-check`: all three manifests (`packages/labs`, `packages/react`, `packages/theme`) verified **byte-identical** after the `localNames` removal — the strongest zero-behavior-change evidence for item 2