### PR TITLE
:wrench: Share consumer Vite config from internal/config

### DIFF
--- a/apps/vrt/mise.toml
+++ b/apps/vrt/mise.toml
@@ -11,6 +11,7 @@ sources = [
   "vite.config.ts",
   "tsconfig.json",
   "package.json",
+  "../../internal/config/src/vite.ts",
   "../../packages/*/src/**/*.visual.tsx",
   "../../packages/*/src/**/examples/*",
 ]

--- a/apps/vrt/vite.config.ts
+++ b/apps/vrt/vite.config.ts
@@ -7,11 +7,11 @@ import { defineConfig } from "vite";
 const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 export default defineConfig(({ command }) => ({
-  plugins: [stylex.vite(stylexPluginOptions(command)), react()],
+  plugins: [stylex.vite(stylexPluginOptions({ command })), react()],
   resolve: {
     // Dev aliases workspace packages to their sources so a failing scene can
     // be debugged with HMR; production builds — what VRT screenshots — consume
     // built dist for consumer fidelity. Rationale lives with the helper.
-    alias: workspaceSourceAliases(workspaceRoot, command),
+    alias: workspaceSourceAliases({ workspaceRoot, command }),
   },
 }));

--- a/apps/vrt/vite.config.ts
+++ b/apps/vrt/vite.config.ts
@@ -1,66 +1,17 @@
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 import stylex from "@stylexjs/unplugin";
+import { stylexPluginOptions, workspaceSourceAliases } from "@urban-ui/config/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url));
-const pkg = (...segments: string[]) => path.join(workspaceRoot, "packages", ...segments);
 
 export default defineConfig(({ command }) => ({
-  plugins: [
-    // Before the react plugin to preserve Fast Refresh. The unplugin
-    // auto-discovers StyleX packages in node_modules (@urban-ui/theme,
-    // @urban-ui/react) — the consumer-compiles contract of ADR-0005.
-    stylex.vite({
-      useCSSLayers: true,
-      // Readable debug class names while developing.
-      dev: command === "serve",
-      devMode: "full",
-    }),
-    react(),
-  ],
+  plugins: [stylex.vite(stylexPluginOptions(command)), react()],
   resolve: {
     // Dev aliases workspace packages to their sources so a failing scene can
     // be debugged with HMR; production builds — what VRT screenshots — consume
-    // built dist for consumer fidelity. Deliberately NOT a global `source`
-    // resolve condition: third-party packages (react-aria-components) declare
-    // `source` conditions pointing at files absent from their published
-    // tarballs, which breaks resolution outright.
-    alias:
-      command === "serve"
-        ? [
-            {
-              find: /^@urban-ui\/theme$/,
-              replacement: pkg("theme", "src", "index.ts"),
-            },
-            {
-              // tokens.stylex is deliberately NOT aliased: StyleX hashes var
-              // names from the defining module's identity, and the compiler
-              // resolves token imports in *other* files through package
-              // exports to dist. Serving the source tokens module would
-              // define source-hashed vars that no compiled rule references —
-              // classes apply but every var() is undefined (unstyled page).
-              find: /^@urban-ui\/theme\/(?!tokens\.stylex$)(.+)$/,
-              replacement: pkg("theme", "src", "$1.ts"),
-            },
-            {
-              find: /^@urban-ui\/react$/,
-              replacement: pkg("react", "src", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/react\/(.+)$/,
-              replacement: pkg("react", "src", "$1", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/labs$/,
-              replacement: pkg("labs", "src", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/labs\/(.+)$/,
-              replacement: pkg("labs", "src", "$1", "index.ts"),
-            },
-          ]
-        : [],
+    // built dist for consumer fidelity. Rationale lives with the helper.
+    alias: workspaceSourceAliases(workspaceRoot, command),
   },
 }));

--- a/apps/workbench/mise.toml
+++ b/apps/workbench/mise.toml
@@ -10,6 +10,7 @@ sources = [
   "vite.config.ts",
   "tsconfig.json",
   "package.json",
+  "../../internal/config/src/vite.ts",
   "../../packages/*/dist/**/*",
 ]
 outputs = ["dist/**/*"]

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,12 +1,11 @@
-import path from "node:path";
 import { fileURLToPath } from "node:url";
 import stylex from "@stylexjs/unplugin";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import { stylexPluginOptions, workspaceSourceAliases } from "@urban-ui/config/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url));
-const pkg = (...segments: string[]) => path.join(workspaceRoot, "packages", ...segments);
 
 export default defineConfig(({ command }) => ({
   // GitHub Pages serves the workbench from /<repo>/ — the deploy workflow
@@ -17,58 +16,13 @@ export default defineConfig(({ command }) => ({
     // src/routes/. Must come before react() so route files are transformed
     // against an up-to-date tree.
     tanstackRouter({ target: "react" }),
-    // Before the react plugin to preserve Fast Refresh. The unplugin
-    // auto-discovers StyleX packages in node_modules (@urban-ui/theme,
-    // @urban-ui/react) — the consumer-compiles contract of ADR-0005.
-    stylex.vite({
-      useCSSLayers: true,
-      // Readable debug class names while developing.
-      dev: command === "serve",
-      devMode: "full",
-    }),
+    stylex.vite(stylexPluginOptions(command)),
     react(),
   ],
   resolve: {
     // Dev aliases workspace packages to their sources so edits in packages/*
     // HMR straight into the workbench without a rebuild; production builds
-    // consume built dist — consumer fidelity. Deliberately NOT a global
-    // `source` resolve condition: third-party packages (react-aria-components)
-    // declare `source` conditions pointing at files absent from their
-    // published tarballs, which breaks resolution outright.
-    alias:
-      command === "serve"
-        ? [
-            {
-              find: /^@urban-ui\/theme$/,
-              replacement: pkg("theme", "src", "index.ts"),
-            },
-            {
-              // tokens.stylex is deliberately NOT aliased: StyleX hashes var
-              // names from the defining module's identity, and the compiler
-              // resolves token imports in *other* files through package
-              // exports to dist. Serving the source tokens module would
-              // define source-hashed vars that no compiled rule references —
-              // classes apply but every var() is undefined (unstyled page).
-              find: /^@urban-ui\/theme\/(?!tokens\.stylex$)(.+)$/,
-              replacement: pkg("theme", "src", "$1.ts"),
-            },
-            {
-              find: /^@urban-ui\/react$/,
-              replacement: pkg("react", "src", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/react\/(.+)$/,
-              replacement: pkg("react", "src", "$1", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/labs$/,
-              replacement: pkg("labs", "src", "index.ts"),
-            },
-            {
-              find: /^@urban-ui\/labs\/(.+)$/,
-              replacement: pkg("labs", "src", "$1", "index.ts"),
-            },
-          ]
-        : [],
+    // consume built dist — consumer fidelity. Rationale lives with the helper.
+    alias: workspaceSourceAliases(workspaceRoot, command),
   },
 }));

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -16,13 +16,13 @@ export default defineConfig(({ command }) => ({
     // src/routes/. Must come before react() so route files are transformed
     // against an up-to-date tree.
     tanstackRouter({ target: "react" }),
-    stylex.vite(stylexPluginOptions(command)),
+    stylex.vite(stylexPluginOptions({ command })),
     react(),
   ],
   resolve: {
     // Dev aliases workspace packages to their sources so edits in packages/*
     // HMR straight into the workbench without a rebuild; production builds
     // consume built dist — consumer fidelity. Rationale lives with the helper.
-    alias: workspaceSourceAliases(workspaceRoot, command),
+    alias: workspaceSourceAliases({ workspaceRoot, command }),
   },
 }));

--- a/internal/config/package.json
+++ b/internal/config/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
+    "./vite": "./src/vite.ts",
     "./tsconfig.base.json": "./tsconfig.base.json",
     "./oxlint.base.json": "./oxlint.base.json"
   },

--- a/internal/config/src/vite.ts
+++ b/internal/config/src/vite.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared Vite configuration for applications consuming the @urban-ui packages.
+ *
+ * This module encodes what a consumer app must configure — the StyleX
+ * compilation step and, for in-repo apps, dev-time source aliases — so the
+ * workspace apps (workbench, VRT) stay in lockstep. It is the seed of the
+ * eventual "getting started" documentation.
+ *
+ * Deliberately dependency-free and structurally typed: consumers own their
+ * own `vite` and `@stylexjs/unplugin` installs and spread these plain
+ * objects/arrays into their own `defineConfig`.
+ */
+
+/**
+ * Options for the StyleX compiler — pass to `stylex.vite(...)` from
+ * `@stylexjs/unplugin`, registered *before* `react()` to preserve Fast
+ * Refresh. The unplugin auto-discovers StyleX packages in node_modules
+ * (@urban-ui/theme, @urban-ui/react) — the consumer-compiles contract of
+ * ADR-0005.
+ */
+export function stylexPluginOptions(command: "build" | "serve") {
+  return {
+    useCSSLayers: true,
+    // Readable debug class names while developing.
+    dev: command === "serve",
+    devMode: "full",
+  } as const;
+}
+
+/**
+ * Serve-only aliases pointing @urban-ui package specifiers at their workspace
+ * sources — for `resolve.alias` in the in-repo apps.
+ *
+ * Dev aliases the packages to source so edits in packages/* HMR straight into
+ * the app without a rebuild; production builds get no aliases and resolve the
+ * built dist through package exports — consumer fidelity. Deliberately NOT a
+ * global `source` resolve condition: third-party packages
+ * (react-aria-components) declare `source` conditions pointing at files absent
+ * from their published tarballs, which breaks resolution outright.
+ *
+ * @param workspaceRoot Absolute path to the repository root. Compute it at
+ *   the call site — `fileURLToPath(new URL("../..", import.meta.url))` — Vite
+ *   bundles config files and rewrites `import.meta.url` to the config file's
+ *   own path, so it cannot be derived reliably in here.
+ */
+export function workspaceSourceAliases(workspaceRoot: string, command: "build" | "serve") {
+  if (command !== "serve") {
+    return [];
+  }
+  // Plain string joins keep this module free of node builtins (and therefore
+  // of @types/node); Vite accepts forward-slash paths on every platform.
+  const packagesDir = `${workspaceRoot.replace(/[/\\]+$/, "")}/packages`;
+  const pkg = (...segments: string[]) => [packagesDir, ...segments].join("/");
+  return [
+    {
+      find: /^@urban-ui\/theme$/,
+      replacement: pkg("theme", "src", "index.ts"),
+    },
+    {
+      // tokens.stylex is deliberately NOT aliased: StyleX hashes var
+      // names from the defining module's identity, and the compiler
+      // resolves token imports in *other* files through package
+      // exports to dist. Serving the source tokens module would
+      // define source-hashed vars that no compiled rule references —
+      // classes apply but every var() is undefined (unstyled page).
+      find: /^@urban-ui\/theme\/(?!tokens\.stylex$)(.+)$/,
+      replacement: pkg("theme", "src", "$1.ts"),
+    },
+    {
+      find: /^@urban-ui\/react$/,
+      replacement: pkg("react", "src", "index.ts"),
+    },
+    {
+      find: /^@urban-ui\/react\/(.+)$/,
+      replacement: pkg("react", "src", "$1", "index.ts"),
+    },
+    {
+      find: /^@urban-ui\/labs$/,
+      replacement: pkg("labs", "src", "index.ts"),
+    },
+    {
+      find: /^@urban-ui\/labs\/(.+)$/,
+      replacement: pkg("labs", "src", "$1", "index.ts"),
+    },
+  ];
+}

--- a/internal/config/src/vite.ts
+++ b/internal/config/src/vite.ts
@@ -18,7 +18,7 @@
  * (@urban-ui/theme, @urban-ui/react) — the consumer-compiles contract of
  * ADR-0005.
  */
-export function stylexPluginOptions(command: "build" | "serve") {
+export function stylexPluginOptions({ command }: { command: "build" | "serve" }) {
   return {
     useCSSLayers: true,
     // Readable debug class names while developing.
@@ -38,12 +38,18 @@ export function stylexPluginOptions(command: "build" | "serve") {
  * (react-aria-components) declare `source` conditions pointing at files absent
  * from their published tarballs, which breaks resolution outright.
  *
- * @param workspaceRoot Absolute path to the repository root. Compute it at
- *   the call site — `fileURLToPath(new URL("../..", import.meta.url))` — Vite
- *   bundles config files and rewrites `import.meta.url` to the config file's
- *   own path, so it cannot be derived reliably in here.
+ * @param options.workspaceRoot Absolute path to the repository root. Compute
+ *   it at the call site — `fileURLToPath(new URL("../..", import.meta.url))` —
+ *   Vite bundles config files and rewrites `import.meta.url` to the config
+ *   file's own path, so it cannot be derived reliably in here.
  */
-export function workspaceSourceAliases(workspaceRoot: string, command: "build" | "serve") {
+export function workspaceSourceAliases({
+  workspaceRoot,
+  command,
+}: {
+  workspaceRoot: string;
+  command: "build" | "serve";
+}) {
   if (command !== "serve") {
     return [];
   }


### PR DESCRIPTION

## What

Extracts the ~45 lines duplicated byte-identically between `apps/workbench/vite.config.ts` and `apps/vrt/vite.config.ts` into a new `@urban-ui/config/vite` module (`internal/config/src/vite.ts`):

- **`stylexPluginOptions(command)`** — options for `stylex.vite(...)`, with the plugin-ordering and consumer-compiles (ADR-0005) rationale in its doc comment.
- **`workspaceSourceAliases(workspaceRoot, command)`** — the serve-only aliases pointing `@urban-ui/*` at workspace sources, including the load-bearing `tokens.stylex` carve-out and its explanatory comment, preserved verbatim in the shared location.

Both apps now spread these into their own `defineConfig`; app-specific concerns (base path, TanStack Router plugin, per-app comment framing) stay in the apps. Both apps' mise build `sources` gain the shared module so content-hash freshness tracks it.

## Why

Beyond deduplication, this module is the seed of the eventual "getting started" documentation: it encodes exactly what a consumer application must configure to use the packages (StyleX compilation via unplugin, and for in-repo apps, dev source aliases).

Notes on shape:
- Wired via the exports map as `"./vite": "./src/vite.ts"` (source export). Vite's config bundler inlines TS package imports and the apps typecheck under `moduleResolution: bundler`, so no build-ordering coupling on `internal/config` dist.
- Zero new dependencies in `internal/config`: the helpers return plain objects/arrays typed structurally (no `vite` / `@stylexjs/unplugin` imports), and path joining uses plain string joins so the module needs neither node builtins nor `@types/node` (which isn't in scope for this package).
- `workspaceRoot` is passed in by the apps rather than derived internally: Vite's config bundling rewrites `import.meta.url` to the config file's own path, so the shared module can't locate itself reliably.

## Validation

- `hk check --all` — all gates pass (oxlint, oxfmt, typecheck).
- `mise run '//apps/workbench:build'` and `mise run '//apps/vrt:build'` — both succeed.
- Booted `vite dev` for workbench and verified serve-mode resolution in the transformed modules: `@urban-ui/react/button` resolves to `packages/react/src/button/index.ts` (source alias active) while `@urban-ui/theme/tokens.stylex` resolves to `packages/theme/dist/tokens.stylex.js` (carve-out intact — compiled rules and token vars stay in agreement).

Refs: bead `urban-ui-ysn`