### PR TITLE
:wrench: Derive consumer-smoke probes from workspace sources

### DIFF
--- a/internal/exfil/src/consumer-smoke.test.ts
+++ b/internal/exfil/src/consumer-smoke.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { devDependencyVersion, extractAccentToken } from "../src/consumer-smoke.js";
+import { devDependencyVersion, extractAccentToken } from "./consumer-smoke.js";
 
 const REPO_ROOT = path.join(import.meta.dirname, "..", "..", "..");
 

--- a/internal/exfil/src/consumer-smoke.ts
+++ b/internal/exfil/src/consumer-smoke.ts
@@ -12,12 +12,33 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { packAndVerify } from "./publish.js";
 
-/** The accent token value from @urban-ui/theme — the cross-package proof. */
-const TOKEN_PROBE = "#4f46e5";
 const LABEL_PROBE = "Consumer smoke";
+
+/** Where the theme declares its tokens — the accent probe is derived from here. */
+const THEME_TOKENS_PATH = path.join("packages", "theme", "src", "tokens.stylex.ts");
 
 function run(cwd: string, command: string, args: string[]): string {
   return execFileSync(command, args, { cwd, encoding: "utf8" });
+}
+
+/**
+ * Extract the accent token literal from the theme tokens source, so the smoke
+ * probe tracks theme changes instead of duplicating the value.
+ */
+export function extractAccentToken(source: string): string | undefined {
+  return source.match(/\baccent:\s*"([^"]+)"/)?.[1];
+}
+
+/** Read a devDependency version from a workspace package.json. */
+export function devDependencyVersion(
+  repoRoot: string,
+  workspace: string,
+  name: string,
+): string | undefined {
+  const pkg = JSON.parse(readFileSync(path.join(repoRoot, workspace, "package.json"), "utf8")) as {
+    devDependencies?: Record<string, string>;
+  };
+  return pkg.devDependencies?.[name];
 }
 
 function catalogVersions(repoRoot: string): Record<string, string> {
@@ -29,6 +50,49 @@ function catalogVersions(repoRoot: string): Record<string, string> {
 
 export function consumerSmoke(repoRoot: string): { dir: string; issues: string[] } {
   const issues: string[] = [];
+
+  const tokenProbe = extractAccentToken(
+    readFileSync(path.join(repoRoot, THEME_TOKENS_PATH), "utf8"),
+  );
+  if (tokenProbe === undefined) {
+    issues.push(
+      `Could not derive the accent probe from ${THEME_TOKENS_PATH} — no \`accent: "…"\` literal found in the theme source`,
+    );
+  }
+
+  const unpluginVersion = devDependencyVersion(
+    repoRoot,
+    path.join("packages", "react"),
+    "@stylexjs/unplugin",
+  );
+  if (unpluginVersion === undefined) {
+    issues.push(
+      "Could not derive the @stylexjs/unplugin version from packages/react devDependencies",
+    );
+  }
+  const pluginReactVersion = devDependencyVersion(
+    repoRoot,
+    path.join("apps", "workbench"),
+    "@vitejs/plugin-react",
+  );
+  if (pluginReactVersion === undefined) {
+    issues.push(
+      "Could not derive the @vitejs/plugin-react version from apps/workbench devDependencies",
+    );
+  }
+  const viteVersion = devDependencyVersion(repoRoot, path.join("apps", "workbench"), "vite");
+  if (viteVersion === undefined) {
+    issues.push("Could not derive the vite version from apps/workbench devDependencies");
+  }
+  if (
+    tokenProbe === undefined ||
+    unpluginVersion === undefined ||
+    pluginReactVersion === undefined ||
+    viteVersion === undefined
+  ) {
+    return { dir: "", issues };
+  }
+
   const theme = packAndVerify(path.join(repoRoot, "packages", "theme"));
   const react = packAndVerify(path.join(repoRoot, "packages", "react"));
   issues.push(...theme.issues, ...react.issues);
@@ -53,9 +117,9 @@ export function consumerSmoke(repoRoot: string): { dir: string; issues: string[]
           "react-aria-components": catalog["react-aria-components"] ?? "^1.19.0",
         },
         devDependencies: {
-          "@stylexjs/unplugin": "0.19.0",
-          "@vitejs/plugin-react": "6.0.3",
-          vite: "8.1.3",
+          "@stylexjs/unplugin": unpluginVersion,
+          "@vitejs/plugin-react": pluginReactVersion,
+          vite: viteVersion,
         },
       },
       null,
@@ -106,9 +170,9 @@ export function consumerSmoke(repoRoot: string): { dir: string; issues: string[]
     .map((file) => readFileSync(path.join(assets, file), "utf8"))
     .join("\n");
 
-  if (!css.includes(TOKEN_PROBE)) {
+  if (!css.includes(tokenProbe)) {
     issues.push(
-      `Compiled consumer CSS lacks the theme accent value ${TOKEN_PROBE} — cross-package StyleX compilation failed`,
+      `Compiled consumer CSS lacks the theme accent value ${tokenProbe} (derived from ${THEME_TOKENS_PATH}) — cross-package StyleX compilation failed`,
     );
   }
   if (!js.includes(LABEL_PROBE)) {

--- a/internal/exfil/test/consumer-smoke.test.ts
+++ b/internal/exfil/test/consumer-smoke.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { devDependencyVersion, extractAccentToken } from "../src/consumer-smoke.js";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..", "..", "..");
+
+describe("extractAccentToken", () => {
+  it("pulls the accent literal, not accentText", () => {
+    const source = [
+      `export const colors = stylex.defineVars({`,
+      `  surface: "#ffffff",`,
+      `  accent: "#123abc",`,
+      `  accentText: "#ffffff",`,
+      `});`,
+    ].join("\n");
+    expect(extractAccentToken(source)).toBe("#123abc");
+  });
+
+  it("returns undefined when no accent literal exists", () => {
+    expect(extractAccentToken(`const nope = "#4f46e5";`)).toBeUndefined();
+  });
+
+  it("derives a probe from the real theme source", () => {
+    const source = readFileSync(
+      path.join(REPO_ROOT, "packages", "theme", "src", "tokens.stylex.ts"),
+      "utf8",
+    );
+    expect(extractAccentToken(source)).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+  });
+});
+
+describe("devDependencyVersion", () => {
+  it("reads declared versions from workspace package.json files", () => {
+    expect(
+      devDependencyVersion(REPO_ROOT, path.join("packages", "react"), "@stylexjs/unplugin"),
+    ).toMatch(/^\d/);
+    expect(devDependencyVersion(REPO_ROOT, path.join("apps", "workbench"), "vite")).toMatch(/^\d/);
+  });
+
+  it("returns undefined for undeclared dependencies", () => {
+    expect(
+      devDependencyVersion(REPO_ROOT, path.join("packages", "react"), "not-a-real-dependency"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION

Implements bead **urban-ui-ah9**.

## What

- The accent probe in `internal/exfil/src/consumer-smoke.ts` was a hardcoded `#4f46e5` duplicating `packages/theme/src/tokens.stylex.ts`. It is now derived at runtime by reading the theme tokens source and extracting the `accent: "…"` literal, so the smoke tracks theme changes automatically.
- The scratch consumer's `@stylexjs/unplugin`, `@vitejs/plugin-react`, and `vite` versions were hardcoded literals. They are now read from where the workspace already declares them (`packages/react` devDependencies for unplugin, `apps/workbench` devDependencies for plugin-react and vite), so they can't drift.
- Failure messages stay accurate and distinct: "could not derive the accent probe / version from <source>" aborts before packing, versus "compiled consumer CSS lacks the theme accent value <probe> (derived from <path>) — cross-package StyleX compilation failed" after the build.
- New unit tests for the derivation helpers in `internal/exfil/test/consumer-smoke.test.ts` (accent extraction incl. the `accentText` near-miss, real theme source, devDependency lookup and undeclared-dependency miss).

## Why

A theme accent change would previously have broken the smoke with a misleading "cross-package StyleX compilation failed", and pinned tool versions in the scratch consumer could silently drift from what the workspace actually uses.

## Validation

- `bun run test` in `internal/exfil` — 30 pass, 0 fail (3 files)
- `hk check --all` — oxfmt, oxlint, typecheck all pass
- `mise run consumer-smoke` — passes end-to-end ("Consumer smoke passed — packed tarballs compile and render in a scratch Vite app")
- Failure-mode sanity check: temporarily changed the theme accent to `#0aa66d`, re-ran `mise run consumer-smoke` — still passed with the probe derived from source, and the compiled consumer CSS was confirmed to contain `#0aa66d`; the temporary theme edit was then reverted and the smoke re-run green on the original value.