### PR TITLE
:book: Design language groundwork — product framing, theme contract, rule register (urban-ui-727)

### DIFF
--- a/.claude/skills/rule/SKILL.md
+++ b/.claude/skills/rule/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: rule
+description: Record a design-language rule in docs/rules/ while it's hot — when a snag, violation, or decision reveals a rule worth enforcing. Use when the user says "add a rule", "record this as a rule", "this should be a rule", or a review/deviation discussion converges on a new convention.
+argument-hint: "<the rule, roughly stated>"
+---
+
+# Rule
+
+Record a design-language rule as a per-file entry under `docs/rules/`, indexed in `docs/rules.md`. Rules are evidence-based: they get recorded when reality proves them, and current violations get fixed (or filed) at recording time. The model (strata, strictness, deviation format) lives in `docs/knowledge/design-language.md`.
+
+## Steps
+
+1. **Capture the one-liner first** — a single sentence stating the rule, RFC-2119 style where it helps (MUST/SHOULD). If `$ARGUMENTS` is rough, sharpen it with the user before proceeding. Decision-rule crisp: agents amplify vagueness.
+2. **Sort it**:
+   - **stratum** — `contract` (mechanical/neutral: formats, invariants, schema) · `language` (opinionated but theme-agnostic grammar) · `flagship` (the cyberpunk identity's values). Test: would a non-cyberpunk theme still obey it? yes → language or contract; no → flagship.
+   - **strictness** — `law` (breaking it exits the language; written justification) · `default` (expected choice; deviate with annotation) · `leaning` (soft preference; deviate freely).
+   - If genuinely unsure, ask the user — one question, both axes at once.
+3. **Slug it** — flat kebab-case, short, imperative-ish (`no-margin`, `browser-cursor`). Check uniqueness against `docs/rules/`. No numbers, no category prefixes.
+4. **Write `docs/rules/<slug>.md`** in the format below. Rationale carries the *why* (the snag that proved it); examples are Biome-style incorrect/correct pairs, plus a sanctioned-deviation example where one is already known.
+5. **Index it** — add a row to the matching stratum table in `docs/rules.md`: `| [[<slug>]] | <short description distilled from the rationale> |`.
+6. **Fix current violations** — grep/search for existing violations. Fix them in this change where cheap; where not, file a bead referencing the rule and note it in the Evidence section.
+7. **Remind the deviation format** if the rule came from a deviation discussion: `// deviation(<slug>): <reason>`.
+
+## Template
+
+```markdown
+---
+slug: <slug>
+stratum: contract | language | flagship
+strictness: law | default | leaning
+---
+
+# <slug>
+
+<One-sentence rule statement.>
+
+## Rationale
+
+<Why — the forces, the snag that proved it, what breaks without it.>
+
+## Examples
+
+### Incorrect
+
+<code or description>
+
+### Correct
+
+<code or description>
+
+### Sanctioned deviation (optional)
+
+// deviation(<slug>): <known-legitimate reason>
+
+## Evidence
+
+<What earned it: date/session/bead, violations found and fixed or filed. Deviation tallies append here over time.>
+```
+
+## Constraints
+
+- One rule per file; one file per rule. Never batch unrelated rules into one entry.
+- Do not remove or demote rules in this skill — removal is deliberate, separately managed (currently deferred; raise it with the user instead).
+- Keep entries compact — the rationale is a paragraph, not an essay.

--- a/.claude/skills/rule/SKILL.md
+++ b/.claude/skills/rule/SKILL.md
@@ -14,7 +14,8 @@ Record a design-language rule as a per-file entry under `docs/rules/`, indexed i
 2. **Sort it**:
    - **stratum** — `contract` (mechanical/neutral: formats, invariants, schema) · `language` (opinionated but theme-agnostic grammar) · `flagship` (the cyberpunk identity's values). Test: would a non-cyberpunk theme still obey it? yes → language or contract; no → flagship.
    - **strictness** — `law` (breaking it exits the language; written justification) · `default` (expected choice; deviate with annotation) · `leaning` (soft preference; deviate freely).
-   - If genuinely unsure, ask the user — one question, both axes at once.
+   - **enforcement** — `machine` (lintable or computable — a grep, a type, a contrast check) · `review` (a crisp yes/no question answerable at the site) · `judgment` (identity/principle; no per-site check). Test: could a dumb tool flag a violation? yes → machine; could an agent answer one question about the site? yes → review; else judgment.
+   - If genuinely unsure, ask the user — one question, all axes at once.
 3. **Slug it** — flat kebab-case, short, imperative-ish (`no-margin`, `browser-cursor`). Check uniqueness against `docs/rules/`. No numbers, no category prefixes.
 4. **Write `docs/rules/<slug>.md`** in the format below. Rationale carries the *why* (the snag that proved it); examples are Biome-style incorrect/correct pairs, plus a sanctioned-deviation example where one is already known.
 5. **Index it** — add a row to the matching stratum table in `docs/rules.md`: `| [[<slug>]] | <short description distilled from the rationale> |`.
@@ -28,6 +29,7 @@ Record a design-language rule as a per-file entry under `docs/rules/`, indexed i
 slug: <slug>
 stratum: contract | language | flagship
 strictness: law | default | leaning
+enforcement: machine | review | judgment
 ---
 
 # <slug>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Repository documentation is a wiki-linked graph under `docs/`. Enter through the
 - [docs/adr.md](docs/adr.md) — architectural decision records
 - [docs/knowledge.md](docs/knowledge.md) — durable conventions and contracts
 - [docs/prd.md](docs/prd.md) — product requirements documents
+- [docs/rules.md](docs/rules.md) — the design-language rule register (add via the `rule` skill)
 
 ## Build & Test
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -27,5 +27,6 @@ Records live in `docs/adr/` and are numbered `NNNN-title.md`. Link between recor
 - [[0005-style-shipping-and-package-build]] — consumer-compiles StyleX, peer-dep trio, tsc-only ESM build — **accepted**
 - [[0006-component-quality-stack]] — hand-rolled workbench, committed VRT baselines via Playwright, Vitest units, oxc static gates — **accepted**
 - [[0007-working-model]] — agent-authored, human-reviewed: every gate PR-reviewable and agent-self-serviceable — **accepted**
+- [[0008-global-css-distribution]] — `@urban-ui/theme` ships one static `global.css` (`reset` + `base` cascade layers below StyleX); amends the no-CSS letter of [[0005-style-shipping-and-package-build]] — **accepted**
 
 Living conventions and contracts are not ADRs — they live in the [[knowledge]] index.

--- a/docs/adr/0008-global-css-distribution.md
+++ b/docs/adr/0008-global-css-distribution.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+date: 2026-07-08
+tags: [adr, theme, css, packages]
+---
+
+# ADR-0008 — Global CSS distribution
+
+## Context
+
+- The design language commits to global CSS behaviours no component can carry: a browser-smoothing reset, the [[leading-trim]] law (`text-box-trim`, which every spacing value is tuned against), reduced-motion handling (one global implementation, honoured per [[product-framing]]), and `color-scheme`. StyleX deliberately has no global-styles API — element selectors, resets, and `@font-face` are out of its scope; its own docs pair it with a plain CSS file ordered before its output via cascade layers.
+- [[0005-style-shipping-and-package-build]] establishes consumer-compiles StyleX and states that packages ship no CSS. That posture was about *compiled component* CSS; it did not anticipate static global CSS.
+- Copy-paste distribution (documented snippet) drifts: the trim law is load-bearing for every theme's spacing, and agents-first consumption makes copy-then-diverge likelier, not less.
+- Token-shaped globals need no CSS file at all: `defineVars` emits `:root` custom properties, so font/face vocabularies ride the normal token pipeline. Only `@font-face` (font loading) sits outside — deferred to flagship values work.
+
+## Decision
+
+- `@urban-ui/theme` ships **one static CSS file** (`@urban-ui/theme/global.css`), amending the letter of [[0005-style-shipping-and-package-build]] while keeping its spirit: no *compiled component* CSS ships; this file is static, content-stable, and versioned with the theme.
+- The file declares **two cascade layers**, `reset` then `base`:
+  - `reset` — the adapted Josh Comeau reset plus the animation-timing / `prefers-reduced-motion` snippet. Browser smoothing; a consumer with their own reset opinion can override this layer without breaking urban-ui.
+  - `base` — library law: `text-box-trim` ([[leading-trim]]), `color-scheme`, and future global laws. Not optional; components and spacing values assume it.
+- Consumers import the file in their CSS entry and configure StyleX to declare these layers first (`useCSSLayers: { before: ['reset', 'base'] }`), so all StyleX output wins over both layers deterministically.
+- `urban doctor` verifies the file is imported and the layer ordering is configured.
+- Font vocabularies ship as `defineVars` tokens, not CSS; `@font-face` loading is deferred to flagship values work.
+
+## Consequences
+
+- The leading-trim law and reduced-motion handling are versioned, updatable, and un-driftable — a theme upgrade carries global-law changes.
+- Consumers gain one mandatory import and one bundler option beyond the ADR-0005 setup; doctor makes both checkable.
+- The workbench must adopt the same wiring (`useCSSLayers` object form) — it currently uses `useCSSLayers: true`.
+- Firefox's pending `text-box-trim` support means the base layer degrades gracefully looser until it ships; the design is tuned to the trimmed rendering.
+
+## Open questions
+
+- Whether `global.css` splits per-scheme or per-density content later — none anticipated; revisit only on evidence.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -18,6 +18,7 @@ Records live in `docs/knowledge/`.
 
 ## Records
 
+- [[product-framing]] — what urban-ui is for: the needle and standing decisions (audience, archetype, coherence model, agents-first, scope, themes) that frame all future PRDs
 - [[package-anatomy]] — the contract for what every publishable package contains: layout, component anatomy, authored-guidance template, manifest, definition of done
 - [[release-runbook]] — how a train departs: intent → assembly → merge-as-departure, rehearsal commands, the first-release decision, previews
 - [[watch-items]] — living register of external events, pins, and revisit triggers committed to in ADRs

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -19,6 +19,8 @@ Records live in `docs/knowledge/`.
 ## Records
 
 - [[product-framing]] — what urban-ui is for: the needle and standing decisions (audience, archetype, coherence model, agents-first, scope, themes) that frame all future PRDs
+- [[design-language]] — how rules work: the three strata (contract/language/flagship), the flat evidence-based rule register, the deviation model, and the seed rules
+- [[theme-contract]] — the token architecture: coherence groups, var/group/category/theme tiers, and the per-domain schema (colour, materials, shape, text, space)
 - [[package-anatomy]] — the contract for what every publishable package contains: layout, component anatomy, authored-guidance template, manifest, definition of done
 - [[release-runbook]] — how a train departs: intent → assembly → merge-as-departure, rehearsal commands, the first-release decision, previews
 - [[watch-items]] — living register of external events, pins, and revisit triggers committed to in ADRs

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -20,7 +20,8 @@ Records live in `docs/knowledge/`.
 
 - [[product-framing]] — what urban-ui is for: the needle and standing decisions (audience, archetype, coherence model, agents-first, scope, themes) that frame all future PRDs
 - [[design-language]] — how rules work: the three strata (contract/language/flagship), the flat evidence-based rule register, the deviation model, and the seed rules
-- [[theme-contract]] — the token architecture: coherence groups, var/group/category/theme tiers, and the per-domain schema (colour, materials, shape, text, space)
+- [[theme-contract]] — the normative token inventory: vocabularies, groups, members, cross-scale categories, and open slots — dense and scannable
+- [[theme-guidelines]] — the reasoning behind the token architecture: coherence-group machinery, var/group/category/theme tiers, and per-domain decisions (colour, materials, shape, text, space)
 - [[package-anatomy]] — the contract for what every publishable package contains: layout, component anatomy, authored-guidance template, manifest, definition of done
 - [[release-runbook]] — how a train departs: intent → assembly → merge-as-departure, rehearsal commands, the first-release decision, previews
 - [[watch-items]] — living register of external events, pins, and revisit triggers committed to in ADRs

--- a/docs/knowledge/design-language.md
+++ b/docs/knowledge/design-language.md
@@ -4,7 +4,7 @@ tags: [knowledge, design-language, rules]
 
 # Design language
 
-How rules work in this system: the strata that scope them, the register that holds them, and the deviation model that evolves them. The token schema itself lives in [[theme-contract]]; the product frame in [[product-framing]]. Distilled from the urban-ui-727 tokenisation interrogation.
+How rules work in this system: the strata that scope them, the register that holds them, and the deviation model that evolves them. The token inventory lives in [[theme-contract]], its rationale in [[theme-guidelines]]; the product frame in [[product-framing]]. Distilled from the urban-ui-727 tokenisation interrogation.
 
 ## The three strata
 
@@ -20,12 +20,16 @@ The language was discovered through cyberpunk eyes but is written theme-agnostic
 
 ## The rule register
 
-Rules are a **flat, evidence-based collection**: we hit a snag, we record the rule, we fix current violations, and the record prevents reintroduction. No upfront taxonomy — categorisation and the link-graph come later, from the data. Each rule carries:
+Rules are a **flat, evidence-based collection**: we hit a snag, we record the rule, we fix current violations, and the record prevents reintroduction. No upfront taxonomy — categorisation and the link-graph come later, from the data.
 
+The register lives as **one file per rule** under `docs/rules/`, indexed in [[rules]] (eslint/biome shape: rule-per-page, scannable index). Add rules while they're hot with the `rule` skill; removal is deliberate and separately managed (deferred). Each rule carries:
+
+- **slug** — flat kebab-case identity, cited at deviation sites; no numbers, no category prefixes
 - **stratum** — contract / language / flagship
-- **strictness** — `Law` (breaking it exits the language; written justification required) · `Default` (expected choice; deviate with an inline annotation) · `Leaning` (soft preference; deviate freely)
-- **the rule** — one or two sentences, decision-rule crisp (agents amplify vagueness at machine speed; vague guidance is a correctness bug)
-- **evidence** — what proved it
+- **strictness** — `law` (breaking it exits the language; written justification required) · `default` (expected choice; deviate with an inline annotation) · `leaning` (soft preference; deviate freely)
+- **the rule** — one sentence, decision-rule crisp (agents amplify vagueness at machine speed; vague guidance is a correctness bug)
+- **rationale + examples** — the why, and Biome-style incorrect/correct pairs
+- **evidence** — what proved it; deviation tallies append here
 
 ## Deviation model
 
@@ -37,45 +41,9 @@ A deviation is a call-site contradiction of a decision the system owns — not a
 - **Deviations are data.** Each annotation is a vote: the ramp lacks a step, a rule's stratum/scope is wrong, a predicted category has become real, or a law needs a written exemption. Tallies (greppable by format) drive rule rewrites and demotions.
 - **Standing deviations** (e.g. round avatars under a square-baseline flagship) are annotated once, cited thereafter, and promote into rule text when citations accumulate.
 
-## Seed rules
+## The rules
 
-The register as of the founding session. Format: stratum · strictness — rule.
-
-### Contract
-
-- contract · Law — Every colour is OKLCH (`oklch(L C H / α)`).
-- contract · Law — Tokens are implementation-independent: the contract is a specification; CSS vars, JS values, or conventions are carriers.
-- contract · Law — All text is leading-trimmed; spacing values are tuned to the trimmed rendering.
-- contract · Law — A silhouette never exceeds its bounding box; shape never disturbs spacing.
-- contract · Law — An element's min width/height must exceed its cut size.
-- contract · Law — Categories are empirical: created only on visible clustering + co-movement under real edits.
-- contract · Law — Scheme-flipping derivations are semantic tokens (`advance`/`recede`); call sites never scheme-switch.
-- contract · Default — `fill` takes the scale's seed directly; deviate only when the `fill`×`onFill` AA pairing forces an adjustment.
-- contract · Default — Derived colour values (`color-mix`) are authoring tools; results land as authored group values.
-
-### Language
-
-- language · Law — WCAG AA contrast is the floor for functional content, and it is the material's job to guarantee it ([[product-framing]]).
-- language · Law — Flair never solely carries meaning; a glow may garnish a focus indicator, never be it.
-- language · Law — Interactivity is a class property of a component, never per-instance.
-- language · Law — Interaction states: gesture union `default | hover | press | disabled`; `selected` and `focus` are additive booleans. The word `active` does not exist in the vocabulary.
-- language · Law — Focus is structural: a ring from `static.focus`; emission never substitutes.
-- language · Default — Text is classified by what it balances against: environment → UI scale; itself → editorial scale.
-- language · Default — Emphasis derivations use `advance`/`recede`; the physical pair (`shade`/`tint`) for emphasis is a deviation.
-- language · Default — A header sits tighter to its content than peers sit to each other, at any density.
-- language · Default — Margin folds into the spacing scales: to-edge is `inset`, between is `gap`; a raw margin is a deviation.
-- language · Default — Shape application is site-owned: no theme or global rule dictates which deformations an element carries.
-- language · Default — A chamfer is a single-gesture cut: one profile, no mixed legs-character on one corner.
-- language · Default — Composed components are convenience, never capability: anything shipped composed must be constructable from the language ([[product-framing]]).
-- language · Leaning — Shade/tint are for deriving, not for direct surface colours.
-
-### Flagship
-
-- flagship · Law — Square baseline: chamfers and notches over rounding; `round` profile is the sanctioned exception (standing deviation: avatars, control thumbs).
-- flagship · Law — A cut's job is to host; "nothing, it looks good" fails the existence test. Hosting the light itself counts.
-- flagship · Default — Things light up under the hand: hover → ambient emission, press → hot. A leaning of the identity, not a state-grammar binding.
-- flagship · Default — Emphasis advances by hue, not weight (scope under observation: long-form prose may earn a read-duty exemption via deviation tally).
-- flagship · Leaning — Texture is an abstracted machined motif, never a picture; dense texture crosses into noise field.
+The register lives in [[rules]] — one file per rule under `docs/rules/`, seeded at founding with the contract, language, and flagship rules from the urban-ui-727 sessions.
 
 ### Watches
 

--- a/docs/knowledge/design-language.md
+++ b/docs/knowledge/design-language.md
@@ -1,0 +1,86 @@
+---
+tags: [knowledge, design-language, rules]
+---
+
+# Design language
+
+How rules work in this system: the strata that scope them, the register that holds them, and the deviation model that evolves them. The token schema itself lives in [[theme-contract]]; the product frame in [[product-framing]]. Distilled from the urban-ui-727 tokenisation interrogation.
+
+## The three strata
+
+Every rule belongs to exactly one stratum:
+
+| stratum | nature | enforcement |
+|---|---|---|
+| **token contract** | mechanical, neutral — the group schema, its slots, formats, invariants | the machinery itself (group completeness, generators, static checks) |
+| **design language** | opinionated grammar, theme-agnostic — what makes any urban-ui app read as urban-ui regardless of theme | documented rules, agent-followed, review-enforced |
+| **flagship theme** | the cyberpunk identity — value-level laws (square baseline, cuts-must-host, hue-not-weight emphasis) | flagship values + rules; fully deviatable by another theme |
+
+The language was discovered through cyberpunk eyes but is written theme-agnostically — every rule gets re-examined for hidden flagship assumptions before landing in a lower stratum.
+
+## The rule register
+
+Rules are a **flat, evidence-based collection**: we hit a snag, we record the rule, we fix current violations, and the record prevents reintroduction. No upfront taxonomy — categorisation and the link-graph come later, from the data. Each rule carries:
+
+- **stratum** — contract / language / flagship
+- **strictness** — `Law` (breaking it exits the language; written justification required) · `Default` (expected choice; deviate with an inline annotation) · `Leaning` (soft preference; deviate freely)
+- **the rule** — one or two sentences, decision-rule crisp (agents amplify vagueness at machine speed; vague guidance is a correctness bug)
+- **evidence** — what proved it
+
+## Deviation model
+
+A deviation is a call-site contradiction of a decision the system owns — not a variant prop (sanctioned API), not a scoped theme (sanctioned machinery), not a value the system doesn't govern.
+
+- Deviation is **plain composition at the call site** — a local style layered over the system value, never a fork of the token or recipe.
+- Every deviation carries the annotation: `// deviation(<rule>): <reason>`
+- **Silent overrides are themselves violations** — an un-annotated local override of a governed property is flaggable by any reviewer, human or agent.
+- **Deviations are data.** Each annotation is a vote: the ramp lacks a step, a rule's stratum/scope is wrong, a predicted category has become real, or a law needs a written exemption. Tallies (greppable by format) drive rule rewrites and demotions.
+- **Standing deviations** (e.g. round avatars under a square-baseline flagship) are annotated once, cited thereafter, and promote into rule text when citations accumulate.
+
+## Seed rules
+
+The register as of the founding session. Format: stratum · strictness — rule.
+
+### Contract
+
+- contract · Law — Every colour is OKLCH (`oklch(L C H / α)`).
+- contract · Law — Tokens are implementation-independent: the contract is a specification; CSS vars, JS values, or conventions are carriers.
+- contract · Law — All text is leading-trimmed; spacing values are tuned to the trimmed rendering.
+- contract · Law — A silhouette never exceeds its bounding box; shape never disturbs spacing.
+- contract · Law — An element's min width/height must exceed its cut size.
+- contract · Law — Categories are empirical: created only on visible clustering + co-movement under real edits.
+- contract · Law — Scheme-flipping derivations are semantic tokens (`advance`/`recede`); call sites never scheme-switch.
+- contract · Default — `fill` takes the scale's seed directly; deviate only when the `fill`×`onFill` AA pairing forces an adjustment.
+- contract · Default — Derived colour values (`color-mix`) are authoring tools; results land as authored group values.
+
+### Language
+
+- language · Law — WCAG AA contrast is the floor for functional content, and it is the material's job to guarantee it ([[product-framing]]).
+- language · Law — Flair never solely carries meaning; a glow may garnish a focus indicator, never be it.
+- language · Law — Interactivity is a class property of a component, never per-instance.
+- language · Law — Interaction states: gesture union `default | hover | press | disabled`; `selected` and `focus` are additive booleans. The word `active` does not exist in the vocabulary.
+- language · Law — Focus is structural: a ring from `static.focus`; emission never substitutes.
+- language · Default — Text is classified by what it balances against: environment → UI scale; itself → editorial scale.
+- language · Default — Emphasis derivations use `advance`/`recede`; the physical pair (`shade`/`tint`) for emphasis is a deviation.
+- language · Default — A header sits tighter to its content than peers sit to each other, at any density.
+- language · Default — Margin folds into the spacing scales: to-edge is `inset`, between is `gap`; a raw margin is a deviation.
+- language · Default — Shape application is site-owned: no theme or global rule dictates which deformations an element carries.
+- language · Default — A chamfer is a single-gesture cut: one profile, no mixed legs-character on one corner.
+- language · Default — Composed components are convenience, never capability: anything shipped composed must be constructable from the language ([[product-framing]]).
+- language · Leaning — Shade/tint are for deriving, not for direct surface colours.
+
+### Flagship
+
+- flagship · Law — Square baseline: chamfers and notches over rounding; `round` profile is the sanctioned exception (standing deviation: avatars, control thumbs).
+- flagship · Law — A cut's job is to host; "nothing, it looks good" fails the existence test. Hosting the light itself counts.
+- flagship · Default — Things light up under the hand: hover → ambient emission, press → hot. A leaning of the identity, not a state-grammar binding.
+- flagship · Default — Emphasis advances by hue, not weight (scope under observation: long-form prose may earn a read-duty exemption via deviation tally).
+- flagship · Leaning — Texture is an abstracted machined motif, never a picture; dense texture crosses into noise field.
+
+### Watches
+
+Anticipatory entries — not rules yet, waiting for evidence:
+
+- **accent-overload** — accent does heavy lifting system-wide; cross-scale borrows and accent fatigue in dense screens are the tally that earns a second flavour scale (`complementary` or better-named).
+- **gamepad navigation** — deferred from [[product-framing]]; real game UI will eventually raise it.
+- **spacing-context protocol** — scoped theming covers local pitch; a component needing to *know* its pitch is the evidence for a formal protocol.

--- a/docs/knowledge/design-language.md
+++ b/docs/knowledge/design-language.md
@@ -52,3 +52,4 @@ Anticipatory entries — not rules yet, waiting for evidence:
 - **accent-overload** — accent does heavy lifting system-wide; cross-scale borrows and accent fatigue in dense screens are the tally that earns a second flavour scale (`complementary` or better-named).
 - **gamepad navigation** — deferred from [[product-framing]]; real game UI will eventually raise it.
 - **spacing-context protocol** — scoped theming covers local pitch; a component needing to *know* its pitch is the evidence for a formal protocol.
+- **well surface** — a surface one step *back* (code blocks, troughs). Input backgrounds are probably `neutral.subtle` (controls, not surfaces); a real specimen needing a well *and* a dark-pitched panel at once is the evidence that mints the member.

--- a/docs/knowledge/design-language.md
+++ b/docs/knowledge/design-language.md
@@ -27,6 +27,7 @@ The register lives as **one file per rule** under `docs/rules/`, indexed in [[ru
 - **slug** — flat kebab-case identity, cited at deviation sites; no numbers, no category prefixes
 - **stratum** — contract / language / flagship
 - **strictness** — `law` (breaking it exits the language; written justification required) · `default` (expected choice; deviate with an inline annotation) · `leaning` (soft preference; deviate freely)
+- **enforcement** — `machine` (lintable or computable; destined for the urban cli's gates, surfaced to consumers through their own lint runner) · `review` (a crisp question a reviewer — human or agent — answers at the site) · `judgment` (identity or principle; upheld by taste and discussion, no per-site check). Orthogonal to strictness: a law can be unlintable (`flair-never-sole-carrier`), a default can be numerically checkable (`fill-takes-seed`).
 - **the rule** — one sentence, decision-rule crisp (agents amplify vagueness at machine speed; vague guidance is a correctness bug)
 - **rationale + examples** — the why, and Biome-style incorrect/correct pairs
 - **evidence** — what proved it; deviation tallies append here

--- a/docs/knowledge/product-framing.md
+++ b/docs/knowledge/product-framing.md
@@ -26,7 +26,7 @@ Both app-chrome and in-game UI are named use-cases, leaning game UI. Materials a
 
 ### Coherence model
 
-The invariant is the contract, not the values. The theme schema (density, radii, motion, layers, color systems as *slots*) and the primitive prop grammar (`variant`, `material`, `shape`, …) are system-defined; every value behind them is theme-configurable. Coherence emerges from shared vocabulary, strong defaults, and guidelines; deviation is the consumer's dial. Flair is expressed per-component through props; theme-steered flair is an open design question for the theme contract.
+The invariant is the contract, not the values. The theme schema (density, geometry, motion, layers, color systems as *slots*) and the primitive prop grammar (`variant`, `material`, `shape`, …) are system-defined; every value behind them is theme-configurable. Coherence emerges from shared vocabulary, strong defaults, and guidelines; deviation is the consumer's dial. Flair is expressed per-component through props; theme-steered flair is an open design question for the theme contract.
 
 ### Agents-first, human-legible
 

--- a/docs/knowledge/product-framing.md
+++ b/docs/knowledge/product-framing.md
@@ -1,0 +1,66 @@
+---
+tags: [knowledge, product, design-language]
+---
+
+# Product framing
+
+What urban-ui is for. This is the frame future PRDs sit inside: PRDs add features and functionality to the system; this record holds the needle and the standing decisions that scope them. Distilled from the use-case interrogation for the design-language work (urban-ui-727); the design language and tokenisation layer get their own records ([[design-language]], [[theme-contract]] — forthcoming).
+
+## The needle
+
+An unconstrained learning vehicle — a design system with genuine aesthetic ambition, built agent-first, proven by first-party apps that are themselves learning experiences. Adoption is not the goal; expressive range and craft are.
+
+## Standing decisions
+
+### Audience
+
+First-party ecosystem drives every design decision; public consumers adopt the flavour. Flair is a separable layer over a neutral-capable baseline: "de-cyberpunked" is possible-but-unsupported, never a tested goal.
+
+### Primary archetype
+
+Game-adjacent UI at 4X/RTS information density — Football Manager, Stellaris, Civilization are the reference points. Interactive controls, panels, and layouts are the core surface; editorial content is supported-secondary. Density and flair are one target, not two poles: the primary archetype is simultaneously the flair-maximal and density-maximal case.
+
+### Game UI is real
+
+Both app-chrome and in-game UI are named use-cases, leaning game UI. Materials are defined to survive arbitrary backdrops — an engineering contract (contrast guarantees via scrim/blur/opacity floors), not a styling choice. This also serves high-aesthetic OS-style applications (the linux-ricing bar: translucent, glowing, daily-driver legible). No engine integration or frame budgets in v1; gamepad navigation is deferred but stated ([[watch-items]]).
+
+### Coherence model
+
+The invariant is the contract, not the values. The theme schema (density, radii, motion, layers, color systems as *slots*) and the primitive prop grammar (`variant`, `material`, `shape`, …) are system-defined; every value behind them is theme-configurable. Coherence emerges from shared vocabulary, strong defaults, and guidelines; deviation is the consumer's dial. Flair is expressed per-component through props; theme-steered flair is an open design question for the theme contract.
+
+### Agents-first, human-legible
+
+Docs and guidelines are written for AI agents building apps under human direction: machine-navigable structure, explicit decision rules over prose vibes, examples as executable truth. Humans hold the taste layer — visual comparison and aesthetic judgment stay human. Because guidelines are the coherence-enforcement mechanism and agents amplify them literally, vague guidance is a correctness bug, not a docs-quality issue.
+
+### Accessibility
+
+WCAG AA contrast is the floor for functional content, and it is the *material's* job to guarantee it. Flair never solely carries meaning: a glow may accent a focus ring, never be it. Reduced-motion and reduced-transparency are theme-contract capabilities from day one. Beyond-AA is a non-goal.
+
+### Proving ground
+
+Workbench playground sub-pages held to app standards — full screens, real data shapes, real backdrops: a 4X-style management screen (dense table + panels + overlays over a moody backdrop), later an editorial-themed probe. Agent-built from the guidelines alone, human-reviewed — that loop is the system test for both the design language and the agents-first claim.
+
+### Scope boundary
+
+Primitives plus surface/layout primitives (Panel/Surface, stacks, grids, split layouts, scroll areas) are the priority core — for this archetype, layout is the product as much as controls are. The composed tier stays small and earns its place (data table, command palette): a composed component ships only when the pattern recurs, has real behavioral complexity, and its API is smaller than the guideline explaining it. Everything composed must be constructable by consumers from the design language — composed is convenience, never capability. App-semantic patterns stay guidelines + playground examples. Charts are out of core per the extraction rule ([[0002-package-architecture]]).
+
+### Themes
+
+One flagship theme ships — the cyberpunk identity — dark-first as the working canon: design, VRT baselines, and playground screens run dark by default. Color scheme is a first-degree contract dimension, so light mode is systemically supported even while it trails in polish; flair tokens must define their light-scheme degradation ("undefined in light mode" is not an allowed answer).
+
+### History
+
+v2 exists because styling technology kept dying under previous iterations (stitches, then vanilla-extract) and because agent-built UI is the gap being plugged. The response is to own the contract: the theme schema should outlive any particular styling technology. Previous iterations were generic; v2 is aesthetic-forward — the flair layer is new, unproven territory, hence the proving ground.
+
+### Platform
+
+Desktop-web-first: pointer + keyboard are the designed-for input modes; density and hover patterns get to assume them. RSC compatibility and mobile/touch are soft goals — achievable by design (CSS-variable-carried theming, graceful narrow-viewport degradation) but not focused on.
+
+## Open threads
+
+Owned by the design-language and tokenisation records when they land:
+
+- Theme-steered component flair vs per-component props (the RSC/context tension)
+- Material system mechanics: blur/scrim/opacity-floor math behind the contrast guarantee
+- The actual theme contract slots: density, layers, motion grammar, color derivation
+- Light-scheme degradation rules for glow/material tokens

--- a/docs/knowledge/theme-contract.md
+++ b/docs/knowledge/theme-contract.md
@@ -8,7 +8,7 @@ The normative inventory of the token system: every vocabulary, group, member, an
 
 ## Vocabularies
 
-The const storey — ramps and enums the themeable semantics draw from.
+The name storey — the step names and enums the themeable semantics draw from. The names are the contract's invariant; the values behind them (a ramp's steps, `shade`/`tint`'s alphas) are group-configurable like every other value in this document ([[theme-guidelines]]).
 
 | vocabulary | values |
 |---|---|
@@ -98,7 +98,11 @@ Editorial layout subsystem (relatedness levels, container grammar) — **open**,
 | axis | values |
 |---|---|
 | gesture (exclusive) | `default · hover · press · disabled` |
-| additive booleans | `selected` · `focus` |
+| additive booleans | `selected` · `invalid` · `focus` |
+
+- `invalid` styles from the status scales (`danger`) — a sanctioned mapping, never a cross-scale borrow.
+- Nav-current (`aria-current`) renders as `selected` — not a separate state.
+- The boolean axis is growable. The test: a persistent mode, spanning component classes, composing with gestures. States that fail it are component-owned styling, not grammar.
 
 ## Cross-scale categories
 

--- a/docs/knowledge/theme-contract.md
+++ b/docs/knowledge/theme-contract.md
@@ -1,142 +1,118 @@
 ---
-tags: [knowledge, theme, tokens]
+tags: [knowledge, theme, tokens, contract]
 ---
 
 # Theme contract
 
-The token architecture for `@urban-ui/theme`: the machinery that makes values swappable, and the schema each domain fills. This is the **token contract** stratum of [[design-language]] — slots and structure, not values. Flagship values live in code; authoring happens by eye in labs. Framed by [[product-framing]]; package shape in [[0002-package-architecture]]; shipping in [[0005-style-shipping-and-package-build]]. Distilled from the urban-ui-727 tokenisation interrogation.
+The normative inventory of the token system: every vocabulary, group, member, and the categories that cut across them. Implementation-independent — StyleX is one carrier ([[0005-style-shipping-and-package-build]]). Rationale and machinery live in [[theme-guidelines]]; rules and strata in [[design-language]]. Unresolved slots are marked **open** with their owner.
 
-Tokens are **implementation-independent**: the contract is a specification; CSS custom properties, JS values, or documented conventions are carriers. The schema outlives any styling technology.
+## Vocabularies
 
-## Machinery
+The const storey — ramps and enums the themeable semantics draw from.
 
-### The spine
-
-> The themeable unit is a coherence group. A theme is a named set of values at any scope.
-
-| tier | what it is | themeable? |
-|---|---|---|
-| **var** | the atomic value | only as part of its group |
-| **group** | vars designed to move together; completeness enforced here | **yes — the only mechanical boundary** |
-| **category** | a named collection of groups | via its groups |
-| **theme** | a named set of values for any scope — a group, a category, or everything | n/a — it *is* the values |
-
-"Theme" is scope-relative: *the `cosy` spacing theme*, *the high-contrast theme*, *the flagship theme*. The flagship is the default theme — its values **are** the token baselines; everything else themes away from them.
-
-**Categories are empirical.** A category earns its name when its groups visibly cluster in value-space AND real edits move them together (re-pitch, re-hue, re-voice). A category never edited as one, invisible on a plot, is speculative taxonomy — don't create it.
-
-### Structure rules
-
-- **Two-storey where the system owns the curve** — ramps beneath (const vocabulary), themeable semantics above. Applies to text and space. Colour is hue-seeded instead — no shared palette beneath the scales.
-- **Scheme (dark/light) is a facet of values**, not a theme: scheme-affected groups (colour, materials) hold per-scheme values in one entry. Dark is the only authored scheme for now; light is an empty seat at a set table — addable without structural change. Call sites never scheme-switch (see the derivation pairs below).
-- **Scoped application** — a theme applies to a subtree, not only a root. Local pitch (a Card re-pitching spacing for its children) is scoped theming over the one schema, never a second scale.
+| vocabulary | values |
+|---|---|
+| `size` | `xs · sm · md · lg · xl` — one coordinated size-world across UI text, `gap`, `inset`, control sizes |
+| `depth` | small set of absolute px cut sizes — **open** (values: labs) |
+| `profile` | `square · straight · round` |
+| `shade` | numbered black-alpha full colours `oklch(0 0 0 / α)` — physical darkening, scheme-invariant |
+| `tint` | numbered white-alpha full colours — physical lightening, scheme-invariant |
 
 ## Colour
 
-**Every colour is OKLCH** — `oklch(L C H / α)`. Format law, all strata.
+Format: every colour is `oklch(L C H / α)`.
 
-### Scale anatomy
+| group | kind |
+|---|---|
+| `accent` | flavour scale |
+| `neutral` | flavour scale |
+| `positive` · `warning` · `danger` | status scales |
+| `surface` | planes — anatomy **open** (urban-ui-btl) |
+| `static` | scale-less singletons |
+| `advance` · `recede` | emphasis derivation, scheme-variant |
 
-Identical across flavour and status scales. Bands are sub-group vocabulary; fg/bg hue-divergence within a scale is a values freedom.
+Scale anatomy — identical for every flavour and status scale, 12 members:
 
-| band | members | job |
-|---|---|---|
-| **fill** | `subtle` · `fill` | component backgrounds, quiet → emphatic. `fill` takes the seed directly (Default); deviate only when the `fill`×`onFill` AA pairing forces it |
-| **edge** | `border` (recedes) · `line` (advances) | boundaries between layers |
-| **marks** | `ink` · `inkSecondary` · `inkTertiary` · `icon` · `onFill` · `onFillSecondary` | foreground content; `icon` sits below `ink` to optically match |
-| **materials** | `trace` · `glow` — growable | what colour a material effect is in this hue; the physics live in Materials |
+| band | members |
+|---|---|
+| fill | `subtle` · `fill` (= seed) |
+| edge | `border` · `line` |
+| marks | `ink` · `inkSecondary` · `inkTertiary` · `icon` · `onFill` · `onFillSecondary` |
+| materials | `trace` · `glow` |
 
-### Roster
+Other groups:
 
-- **Flavour**: `accent` · `neutral`. `complementary` is deferred — watch for accent-overload deviations (cross-scale borrows, accent fatigue in dense screens) as the evidence that earns it.
-- **Status**: `positive` · `warning` · `danger`. No `info` — that job belongs to `accent`/`neutral` until evidence says otherwise.
-- **`surface`** — the neutral planes. Anatomy deferred to the Layers area: its slots are the layer model wearing colour.
-- Extension is implicit: shipped components conform to this contract; consumers extend it or build adjacent contracts freely.
-
-### Static category
-
-Scale-less app-wide singletons, themeable like any group: `white` · `black` · `disabledInk` · `disabledFill` · `focus`. Disabled is cross-scale by nature (all scales converge on one greyed pair); `focus` is the app-wide focus-ring colour. `currentColor` is CSS machinery, not a token.
-
-### Derivation pairs
-
-| pair | nature | use |
-|---|---|---|
-| `shade` / `tint` | physical, **scheme-invariant**, const ramps of black/white alpha as full colours (for `color-mix`) | absolute darkening/lightening: scrims, shadows, over-media legibility floors |
-| `advance` / `recede` | semantic, **scheme-variant** (advance = shade in light, tint in dark) | all emphasis derivations: hover washes, press moves, selected lifts |
-
-Emphasis via the physical pair is a deviation — it bakes a scheme assumption into the call site.
-
-Parked: the semantic colour-alias layer — cross-scale borrow deviations are the evidence that will earn it.
+| group | members |
+|---|---|
+| `static` | `white` · `black` · `disabledInk` · `disabledFill` · `focus` |
+| `advance` / `recede` | numbered, mirroring `shade`/`tint`; values scheme-faceted |
 
 ## Materials
 
-Two materials, defined by how a surface handles light, plus an orthogonal **emission dial** (radiates; composes with both). Emissive-as-third-material waits for a specimen `solid` at max emission can't express.
+| group | defined as |
+|---|---|
+| `solid` | reflects — backdrop blocked; legibility via `fill`×`onFill` |
+| `glass` | transmits — blur + tint; scrim floor guarantees marks-band AA over any backdrop; reduced-transparency collapses to solid |
+| emission | orthogonal dial, off by default; colour from the scale's `glow` |
 
-| property | `solid` (reflects) | `glass` (transmits) |
-|---|---|---|
-| backdrop | blocked | transmitted: blur + tint; scrim/opacity floor guarantees marks-band AA over **any** backdrop |
-| legibility mechanism | `fill`×`onFill` pairing | the scrim floor — the arbitrary-backdrop contract lives here and only here |
-| grain/texture | allowed, quiet | allowed, quiet |
-| emission | dial, off by default | dial, off by default |
-| reduced-transparency | no-op | collapses toward solid — defined once, here |
-
-- Every component that owns a surface has a material — containers lean glass, controls lean solid; marks never have one. Exposed as a prop where the choice is legitimate.
-- Emission colour comes from the scale's `glow` member; gradients/cores derive via `color-mix` with seed/fill at authoring time. Derived values land as authored group values — no runtime identity math.
-- Grain/texture: slots for asset, density, opacity; colour-agnostic masks over token colour; specifics discovered in labs (masking also serves emissive surfaces).
-
-### Interaction states
-
-- **Interactivity is a class property of the component, never per-instance.** Non-interactive components have no state styling.
-- **Gesture union** (exclusive): `default | hover | press | disabled` — `press`, never `active` (nav-current collision). Disabled suppresses the others.
-- **Additive booleans**: `selected` (a persistent mode — coexists with gestures and disabled) and `focus` (`focus-visible` semantics; composes with everything).
-- **Focus is structural**: a ring drawn from `static.focus`, never an emission level — glow may garnish a focus ring, never be it. Token home (ring width/offset) deferred to the component-category area.
-- Emission-maps-to-states (hover → ambient, press → hot) is a **flagship leaning**, not a contract binding: panels may run ambient emission as atmosphere; solid controls may have crisp no-emission states.
+Var anatomy for all three (blur, tint, scrim floor, grain slots, emission levels) — **open** (missing section, [[theme-guidelines]]).
 
 ## Shape
 
-Two deformation types, by perimeter site; a silhouette is a base rect plus deformations. **Radius is not a concept** — the rounded world is chamfers with `round` profile.
+| token | form |
+|---|---|
+| `depth` | shared ramp (chamfer + notch) |
+| `profile` | enum — chamfer carries one; notch carries one per end |
 
-| type | site | properties |
-|---|---|---|
-| **chamfer** | corner | position (corners/sets) · size (depth ramp) · optional asymmetric legs · **one** profile — a chamfer is a single-gesture cut |
-| **notch** | edge | position (edge + placement) · width × depth (ratio is the aspect; `slot` = narrow×deep preset) · wall · profile **per end** |
-
-- **Tokenised**: the shared **depth ramp** (a few absolute px steps — one tool, one machining vocabulary) and the **profile vocabulary** (`square · straight · round`).
-- **Site-owned**: which elements carry which deformations, where, at what aspect — design decisions, never theme-global. Named presets record recurring recipes, earned not speculative.
-- **Mechanism**: the polygon generator and rendering (clip-path + SVG stroke + drop-shadow halo) are code, not tokens.
-- **Contract invariants**: the bounding box is never exceeded (shape never disturbs spacing, under any theme); min width/height must exceed the cut size.
-- Accepted consequence: de-cyberpunking geometry is per-site work, not a one-line theme edit.
+Invariants: a silhouette never exceeds its bounding box; element min-size must exceed its cut size. Application (which cuts, where) is site-owned — never tokenised.
 
 ## Text
 
-**Leading-trim is a contract law** — `text-box-trim` applied globally; a font's box equals its ink, so every gap and inset around text is optical. Spacing values are tuned to the trimmed rendering; the untrimmed fallback (Firefox, today) degrades gracefully looser.
+Anchor: `md` = `16px / 1rem`, shared by both scales.
 
-**Two scales.** The classification rule: *text balances against its environment (UI) or against itself (editorial).* An error message balances against its field → UI; long-form you actually read → editorial.
+| scale | groups |
+|---|---|
+| UI | `size` ramp + roles: `heading` · `subheading` · `label` · `action` |
+| editorial | roles: `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` |
 
-| scale | shape | roles |
-|---|---|---|
-| **UI** | t-shirt ramp `xs · sm · md · lg · xl` (`md` = 16px/1rem, the shared anchor) + thin semantic roles | `heading` · `subheading` · `label` · `action` — growable |
-| **editorial** | role-first, ramp hidden; generous leading; big differentiation | `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` — growable |
-
-- `heading` exists in both scales and is never shared — a panel heading is wayfinding chrome; an article heading is typographic architecture.
-- The duty taxonomy (announce / read / data) survives as classification guidance — the test an agent applies when placing a new role — not as mechanical structure.
+Per-role var anatomy (family/weight/size/tracking/leading) — **open** (missing section, [[theme-guidelines]]).
 
 ## Space
 
-- **UI spacing**: `gap` (between items) and `inset` (content → edge) over the shared t-shirt ramp. Margin folds in — margin-to-edge is inset, margin-between is gap; a raw margin is a deviation. Width/height are excluded (control sizing belongs to the component-category area).
-- **Editorial layout is its own subsystem** — the relatedness grammar (`cluster / hug / group / section`) and the recursive container grammar (`header? · body · footer?`) live there, opted into for genuine long-form.
-- Kept as a UI-side rule: **a header sits tighter to its content than peers sit to each other** — the one spacing relationship that keeps headed structure legible at any density.
-- `inset` level naming deferred until the Layers area settles.
+| group | levels |
+|---|---|
+| `gap` | `size` vocabulary — between items |
+| `inset` | level names **open** (urban-ui-btl) — content → edge |
 
-## The size vocabulary
+Editorial layout subsystem (relatedness levels, container grammar) — **open**, specced with the editorial probe.
 
-`xs · sm · md · lg · xl` is **one coordinated size-world** across UI text, spacing, and control sizes — a `sm` control wants a `sm` label and `sm` gaps. The coordination contract gets defined with the component-category groups.
+## State grammar
 
-## Open threads
+| axis | values |
+|---|---|
+| gesture (exclusive) | `default · hover · press · disabled` |
+| additive booleans | `selected` · `focus` |
 
-Tracked as beads; owned by future sessions or earned by evidence:
+## Cross-scale categories
 
-- **Layers** — the planes/layer model, `surface` scale anatomy, `inset` level names
-- **Component-category groups** — control sizes, content widths, focus-ring tokens, the t-shirt coordination contract
-- **Motion** — the missing axis; `prefers-reduced-motion` is already law ([[product-framing]])
-- Semantic colour-alias layer (earned by borrow deviations) · `complementary` (earned by accent overload) · emissive-as-material (earned by specimen) · container-grammar componentization
+Categories are empirical ([[design-language]]); these are the earned set. Some cut across domains — that is deliberate and load-bearing.
+
+| category | groups | co-movement edit |
+|---|---|---|
+| flavour | `accent` · `neutral` | re-hue |
+| status | `positive` · `warning` · `danger` | equi-perceptual retune, as one |
+| size-world | UI text ramp · `gap` · `inset` · control sizes (open) | density re-pitch |
+| physical derivation | `shade` · `tint` | never — scheme-invariant by definition |
+| emphasis derivation | `advance` · `recede` | scheme facet swap |
+| scheme-affected | all colour groups · materials | per-scheme values in one entry |
+
+## Open slots
+
+| slot | owner |
+|---|---|
+| `surface` anatomy · `inset` levels | urban-ui-btl (Layers) |
+| control sizes · content widths · focus-ring vars | urban-ui-6yb |
+| motion tokens | urban-ui-ed9 |
+| material/emission var anatomy | deferred to lab + use-cases — urban-ui-s2e |
+| text role var anatomy · UI running-text role | missing section, [[theme-guidelines]] |
+| global CSS: one shipped file, `reset` + `base` layers | decided — ADR amending [[0005-style-shipping-and-package-build]] pending |

--- a/docs/knowledge/theme-contract.md
+++ b/docs/knowledge/theme-contract.md
@@ -27,7 +27,7 @@ Format: every colour is `oklch(L C H / α)`.
 | `accent` | flavour scale |
 | `neutral` | flavour scale |
 | `positive` · `warning` · `danger` | status scales |
-| `surface` | planes — anatomy **open** (urban-ui-btl) |
+| `surface` | planes |
 | `static` | scale-less singletons |
 | `advance` · `recede` | emphasis derivation, scheme-variant |
 
@@ -39,6 +39,13 @@ Scale anatomy — identical for every flavour and status scale, 12 members:
 | edge | `border` · `line` |
 | marks | `ink` · `inkSecondary` · `inkTertiary` · `icon` · `onFill` · `onFillSecondary` |
 | materials | `trace` · `glow` |
+
+`surface` anatomy — background-only jobs (no ink members; foreground comes from `neutral`/`accent`); members are jobs, not a lightness ladder — direction (recessed vs raised panels) is a values decision:
+
+| band | members |
+|---|---|
+| ramp | `canvas` (the plane's ground) · `panel` (container face) · `raised` (one step forward) |
+| plane | `overlay` (child-plane face) · `scrim` (modal recession backdrop, authored from `shade`) |
 
 Other groups:
 
@@ -81,8 +88,8 @@ Role anatomy: UI roles are **voice-only** (`family` · `weight` · `tracking`, +
 
 | group | levels |
 |---|---|
-| `gap` | `size` vocabulary — between items |
-| `inset` | level names **open** (urban-ui-btl) — content → edge |
+| `gap` | `plane · container · control` — defaults between siblings, keyed to what the parent contains; the `size` ramp refines (icon↔label sits below `gap.control`) |
+| `inset` | `plane · container · control` — content → edge, keyed to the layer; `inset.control` is the md-anchor, sized controls chain padding via control sizing (urban-ui-6yb) |
 
 Editorial layout subsystem (relatedness levels, container grammar) — **open**, specced with the editorial probe.
 
@@ -110,7 +117,6 @@ Categories are empirical ([[design-language]]); these are the earned set. Some c
 
 | slot | owner |
 |---|---|
-| `surface` anatomy · `inset` levels | urban-ui-btl (Layers) |
 | control sizes · content widths · focus-ring vars | urban-ui-6yb |
 | motion tokens | urban-ui-ed9 |
 | material/emission var anatomy | deferred to lab + use-cases — urban-ui-s2e |

--- a/docs/knowledge/theme-contract.md
+++ b/docs/knowledge/theme-contract.md
@@ -1,0 +1,142 @@
+---
+tags: [knowledge, theme, tokens]
+---
+
+# Theme contract
+
+The token architecture for `@urban-ui/theme`: the machinery that makes values swappable, and the schema each domain fills. This is the **token contract** stratum of [[design-language]] — slots and structure, not values. Flagship values live in code; authoring happens by eye in labs. Framed by [[product-framing]]; package shape in [[0002-package-architecture]]; shipping in [[0005-style-shipping-and-package-build]]. Distilled from the urban-ui-727 tokenisation interrogation.
+
+Tokens are **implementation-independent**: the contract is a specification; CSS custom properties, JS values, or documented conventions are carriers. The schema outlives any styling technology.
+
+## Machinery
+
+### The spine
+
+> The themeable unit is a coherence group. A theme is a named set of values at any scope.
+
+| tier | what it is | themeable? |
+|---|---|---|
+| **var** | the atomic value | only as part of its group |
+| **group** | vars designed to move together; completeness enforced here | **yes — the only mechanical boundary** |
+| **category** | a named collection of groups | via its groups |
+| **theme** | a named set of values for any scope — a group, a category, or everything | n/a — it *is* the values |
+
+"Theme" is scope-relative: *the `cosy` spacing theme*, *the high-contrast theme*, *the flagship theme*. The flagship is the default theme — its values **are** the token baselines; everything else themes away from them.
+
+**Categories are empirical.** A category earns its name when its groups visibly cluster in value-space AND real edits move them together (re-pitch, re-hue, re-voice). A category never edited as one, invisible on a plot, is speculative taxonomy — don't create it.
+
+### Structure rules
+
+- **Two-storey where the system owns the curve** — ramps beneath (const vocabulary), themeable semantics above. Applies to text and space. Colour is hue-seeded instead — no shared palette beneath the scales.
+- **Scheme (dark/light) is a facet of values**, not a theme: scheme-affected groups (colour, materials) hold per-scheme values in one entry. Dark is the only authored scheme for now; light is an empty seat at a set table — addable without structural change. Call sites never scheme-switch (see the derivation pairs below).
+- **Scoped application** — a theme applies to a subtree, not only a root. Local pitch (a Card re-pitching spacing for its children) is scoped theming over the one schema, never a second scale.
+
+## Colour
+
+**Every colour is OKLCH** — `oklch(L C H / α)`. Format law, all strata.
+
+### Scale anatomy
+
+Identical across flavour and status scales. Bands are sub-group vocabulary; fg/bg hue-divergence within a scale is a values freedom.
+
+| band | members | job |
+|---|---|---|
+| **fill** | `subtle` · `fill` | component backgrounds, quiet → emphatic. `fill` takes the seed directly (Default); deviate only when the `fill`×`onFill` AA pairing forces it |
+| **edge** | `border` (recedes) · `line` (advances) | boundaries between layers |
+| **marks** | `ink` · `inkSecondary` · `inkTertiary` · `icon` · `onFill` · `onFillSecondary` | foreground content; `icon` sits below `ink` to optically match |
+| **materials** | `trace` · `glow` — growable | what colour a material effect is in this hue; the physics live in Materials |
+
+### Roster
+
+- **Flavour**: `accent` · `neutral`. `complementary` is deferred — watch for accent-overload deviations (cross-scale borrows, accent fatigue in dense screens) as the evidence that earns it.
+- **Status**: `positive` · `warning` · `danger`. No `info` — that job belongs to `accent`/`neutral` until evidence says otherwise.
+- **`surface`** — the neutral planes. Anatomy deferred to the Layers area: its slots are the layer model wearing colour.
+- Extension is implicit: shipped components conform to this contract; consumers extend it or build adjacent contracts freely.
+
+### Static category
+
+Scale-less app-wide singletons, themeable like any group: `white` · `black` · `disabledInk` · `disabledFill` · `focus`. Disabled is cross-scale by nature (all scales converge on one greyed pair); `focus` is the app-wide focus-ring colour. `currentColor` is CSS machinery, not a token.
+
+### Derivation pairs
+
+| pair | nature | use |
+|---|---|---|
+| `shade` / `tint` | physical, **scheme-invariant**, const ramps of black/white alpha as full colours (for `color-mix`) | absolute darkening/lightening: scrims, shadows, over-media legibility floors |
+| `advance` / `recede` | semantic, **scheme-variant** (advance = shade in light, tint in dark) | all emphasis derivations: hover washes, press moves, selected lifts |
+
+Emphasis via the physical pair is a deviation — it bakes a scheme assumption into the call site.
+
+Parked: the semantic colour-alias layer — cross-scale borrow deviations are the evidence that will earn it.
+
+## Materials
+
+Two materials, defined by how a surface handles light, plus an orthogonal **emission dial** (radiates; composes with both). Emissive-as-third-material waits for a specimen `solid` at max emission can't express.
+
+| property | `solid` (reflects) | `glass` (transmits) |
+|---|---|---|
+| backdrop | blocked | transmitted: blur + tint; scrim/opacity floor guarantees marks-band AA over **any** backdrop |
+| legibility mechanism | `fill`×`onFill` pairing | the scrim floor — the arbitrary-backdrop contract lives here and only here |
+| grain/texture | allowed, quiet | allowed, quiet |
+| emission | dial, off by default | dial, off by default |
+| reduced-transparency | no-op | collapses toward solid — defined once, here |
+
+- Every component that owns a surface has a material — containers lean glass, controls lean solid; marks never have one. Exposed as a prop where the choice is legitimate.
+- Emission colour comes from the scale's `glow` member; gradients/cores derive via `color-mix` with seed/fill at authoring time. Derived values land as authored group values — no runtime identity math.
+- Grain/texture: slots for asset, density, opacity; colour-agnostic masks over token colour; specifics discovered in labs (masking also serves emissive surfaces).
+
+### Interaction states
+
+- **Interactivity is a class property of the component, never per-instance.** Non-interactive components have no state styling.
+- **Gesture union** (exclusive): `default | hover | press | disabled` — `press`, never `active` (nav-current collision). Disabled suppresses the others.
+- **Additive booleans**: `selected` (a persistent mode — coexists with gestures and disabled) and `focus` (`focus-visible` semantics; composes with everything).
+- **Focus is structural**: a ring drawn from `static.focus`, never an emission level — glow may garnish a focus ring, never be it. Token home (ring width/offset) deferred to the component-category area.
+- Emission-maps-to-states (hover → ambient, press → hot) is a **flagship leaning**, not a contract binding: panels may run ambient emission as atmosphere; solid controls may have crisp no-emission states.
+
+## Shape
+
+Two deformation types, by perimeter site; a silhouette is a base rect plus deformations. **Radius is not a concept** — the rounded world is chamfers with `round` profile.
+
+| type | site | properties |
+|---|---|---|
+| **chamfer** | corner | position (corners/sets) · size (depth ramp) · optional asymmetric legs · **one** profile — a chamfer is a single-gesture cut |
+| **notch** | edge | position (edge + placement) · width × depth (ratio is the aspect; `slot` = narrow×deep preset) · wall · profile **per end** |
+
+- **Tokenised**: the shared **depth ramp** (a few absolute px steps — one tool, one machining vocabulary) and the **profile vocabulary** (`square · straight · round`).
+- **Site-owned**: which elements carry which deformations, where, at what aspect — design decisions, never theme-global. Named presets record recurring recipes, earned not speculative.
+- **Mechanism**: the polygon generator and rendering (clip-path + SVG stroke + drop-shadow halo) are code, not tokens.
+- **Contract invariants**: the bounding box is never exceeded (shape never disturbs spacing, under any theme); min width/height must exceed the cut size.
+- Accepted consequence: de-cyberpunking geometry is per-site work, not a one-line theme edit.
+
+## Text
+
+**Leading-trim is a contract law** — `text-box-trim` applied globally; a font's box equals its ink, so every gap and inset around text is optical. Spacing values are tuned to the trimmed rendering; the untrimmed fallback (Firefox, today) degrades gracefully looser.
+
+**Two scales.** The classification rule: *text balances against its environment (UI) or against itself (editorial).* An error message balances against its field → UI; long-form you actually read → editorial.
+
+| scale | shape | roles |
+|---|---|---|
+| **UI** | t-shirt ramp `xs · sm · md · lg · xl` (`md` = 16px/1rem, the shared anchor) + thin semantic roles | `heading` · `subheading` · `label` · `action` — growable |
+| **editorial** | role-first, ramp hidden; generous leading; big differentiation | `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` — growable |
+
+- `heading` exists in both scales and is never shared — a panel heading is wayfinding chrome; an article heading is typographic architecture.
+- The duty taxonomy (announce / read / data) survives as classification guidance — the test an agent applies when placing a new role — not as mechanical structure.
+
+## Space
+
+- **UI spacing**: `gap` (between items) and `inset` (content → edge) over the shared t-shirt ramp. Margin folds in — margin-to-edge is inset, margin-between is gap; a raw margin is a deviation. Width/height are excluded (control sizing belongs to the component-category area).
+- **Editorial layout is its own subsystem** — the relatedness grammar (`cluster / hug / group / section`) and the recursive container grammar (`header? · body · footer?`) live there, opted into for genuine long-form.
+- Kept as a UI-side rule: **a header sits tighter to its content than peers sit to each other** — the one spacing relationship that keeps headed structure legible at any density.
+- `inset` level naming deferred until the Layers area settles.
+
+## The size vocabulary
+
+`xs · sm · md · lg · xl` is **one coordinated size-world** across UI text, spacing, and control sizes — a `sm` control wants a `sm` label and `sm` gaps. The coordination contract gets defined with the component-category groups.
+
+## Open threads
+
+Tracked as beads; owned by future sessions or earned by evidence:
+
+- **Layers** — the planes/layer model, `surface` scale anatomy, `inset` level names
+- **Component-category groups** — control sizes, content widths, focus-ring tokens, the t-shirt coordination contract
+- **Motion** — the missing axis; `prefers-reduced-motion` is already law ([[product-framing]])
+- Semantic colour-alias layer (earned by borrow deviations) · `complementary` (earned by accent overload) · emissive-as-material (earned by specimen) · container-grammar componentization

--- a/docs/knowledge/theme-contract.md
+++ b/docs/knowledge/theme-contract.md
@@ -72,10 +72,10 @@ Anchor: `md` = `16px / 1rem`, shared by both scales.
 
 | scale | groups |
 |---|---|
-| UI | `size` ramp + roles: `heading` · `subheading` · `label` · `action` |
-| editorial | roles: `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` |
+| UI | ramp: `{fontSize, lineHeight}` per `size` step · voice roles: `heading` · `subheading` · `label` · `action` · `text` |
+| editorial | full roles: `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` |
 
-Per-role var anatomy (family/weight/size/tracking/leading) — **open** (missing section, [[theme-guidelines]]).
+Role anatomy: UI roles are **voice-only** (`family` · `weight` · `tracking`, + a default ramp step; structural constants like `textTransform` live in recipes) — size comes from context (`label` voice × `sm` step). Editorial roles carry the full set (`family` · `weight` · `size` · `tracking` · `leading`). `text` is the UI running-text workhorse (errors, descriptions, helper text).
 
 ## Space
 
@@ -114,5 +114,4 @@ Categories are empirical ([[design-language]]); these are the earned set. Some c
 | control sizes · content widths · focus-ring vars | urban-ui-6yb |
 | motion tokens | urban-ui-ed9 |
 | material/emission var anatomy | deferred to lab + use-cases — urban-ui-s2e |
-| text role var anatomy · UI running-text role | missing section, [[theme-guidelines]] |
 | global CSS: one shipped file, `reset` + `base` layers | decided — ADR amending [[0005-style-shipping-and-package-build]] pending |

--- a/docs/knowledge/theme-guidelines.md
+++ b/docs/knowledge/theme-guidelines.md
@@ -116,7 +116,7 @@ Two deformation types, by perimeter site; a silhouette is a base rect plus defor
 
 | scale | shape | roles |
 |---|---|---|
-| **UI** | t-shirt ramp `xs · sm · md · lg · xl` (`md` = 16px/1rem, the shared anchor) + thin semantic roles | `heading` · `subheading` · `label` · `action` — growable |
+| **UI** | t-shirt ramp of `{fontSize, lineHeight}` pairs (`md` = 16px/1rem, the shared anchor) + **voice-only** roles (`family`/`weight`/`tracking` + default step) — size comes from context, so role and control size never fight | `heading` · `subheading` · `label` · `action` · `text` (running-text workhorse) — growable |
 | **editorial** | role-first, ramp hidden; generous leading; big differentiation | `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` — growable |
 
 - `heading` exists in both scales and is never shared — a panel heading is wayfinding chrome; an article heading is typographic architecture.

--- a/docs/knowledge/theme-guidelines.md
+++ b/docs/knowledge/theme-guidelines.md
@@ -27,7 +27,7 @@ Tokens are **implementation-independent**: the contract is a specification; CSS 
 
 ### Structure rules
 
-- **Two-storey where the system owns the curve** — ramps beneath (const vocabulary), themeable semantics above. Applies to text and space. Colour is hue-seeded instead — no shared palette beneath the scales.
+- **Two-storey where the system owns the curve** — ramps beneath, themeable semantics above; both storeys are groups, configurable whole (a ramp re-pitches as one designed curve, never step-by-step). The vocabulary — the step names — is the invariant, per the coherence model: the contract is fixed, every value behind it is configurable. Applies to text and space. Colour is hue-seeded instead — no shared palette beneath the scales.
 - **Scheme (dark/light) is a facet of values**, not a theme: scheme-affected groups (colour, materials) hold per-scheme values in one entry. Dark is the only authored scheme for now; light is an empty seat at a set table — addable without structural change. Call sites never scheme-switch (see the derivation pairs below).
 - **Scoped application** — a theme applies to a subtree, not only a root. Local pitch (a Card re-pitching spacing for its children) is scoped theming over the one schema, never a second scale.
 
@@ -89,7 +89,8 @@ Two materials, defined by how a surface handles light, plus an orthogonal **emis
 
 - **Interactivity is a class property of the component, never per-instance.** Non-interactive components have no state styling.
 - **Gesture union** (exclusive): `default | hover | press | disabled` — `press`, never `active` (nav-current collision). Disabled suppresses the others.
-- **Additive booleans**: `selected` (a persistent mode — coexists with gestures and disabled) and `focus` (`focus-visible` semantics; composes with everything).
+- **Additive booleans**: `selected` (a persistent mode — coexists with gestures and disabled), `invalid` (failed validation — platform vocabulary via `aria-invalid`/react-aria's `isInvalid`; styles from the `danger` scale, a sanctioned mapping that never counts toward borrow-deviation tallies) and `focus` (`focus-visible` semantics; composes with everything). Nav-current (`aria-current`) renders as `selected` — the collision `press` was chosen to avoid, absorbed rather than minted.
+- **The boolean set is growable.** The test: a persistent mode, spanning component classes, composing with gestures. What fails it stays component-owned (an indeterminate checkbox glyph, a calendar's unavailable day, drag/drop visuals) — the grammar stays small because there's a test, not because reality is ignored.
 - **Focus is structural**: a ring drawn from `static.focus`, never an emission level — glow may garnish a focus ring, never be it. Token home (ring width/offset) deferred to the component-category area.
 - Emission-maps-to-states (hover → ambient, press → hot) is a **flagship leaning**, not a contract binding: panels may run ambient emission as atmosphere; solid controls may have crisp no-emission states.
 

--- a/docs/knowledge/theme-guidelines.md
+++ b/docs/knowledge/theme-guidelines.md
@@ -1,0 +1,143 @@
+---
+tags: [knowledge, theme, tokens]
+---
+
+# Theme guidelines
+
+The token architecture for `@urban-ui/theme`: the machinery that makes values swappable, the shape of each domain, and the reasoning behind both — a decision record with guidelines, not the contract itself. The normative inventory (scales, groups, members, vocabularies) is [[theme-contract]]; this document is the *why* behind it. Flagship values live in code; authoring happens by eye in labs. Framed by [[product-framing]]; rules and strata in [[design-language]]; package shape in [[0002-package-architecture]]; shipping in [[0005-style-shipping-and-package-build]]. Distilled from the urban-ui-727 tokenisation interrogation.
+
+Tokens are **implementation-independent**: the contract is a specification; CSS custom properties, JS values, or documented conventions are carriers. The schema outlives any styling technology.
+
+## Machinery
+
+### The spine
+
+> The themeable unit is a coherence group. A theme is a named set of values at any scope.
+
+| tier | what it is | themeable? |
+|---|---|---|
+| **var** | the atomic value | only as part of its group |
+| **group** | vars designed to move together; completeness enforced here | **yes — the only mechanical boundary** |
+| **category** | a named collection of groups | via its groups |
+| **theme** | a named set of values for any scope — a group, a category, or everything | n/a — it *is* the values |
+
+"Theme" is scope-relative: *the `cosy` spacing theme*, *the high-contrast theme*, *the flagship theme*. The flagship is the default theme — its values **are** the token baselines; everything else themes away from them.
+
+**Categories are empirical.** A category earns its name when its groups visibly cluster in value-space AND real edits move them together (re-pitch, re-hue, re-voice). A category never edited as one, invisible on a plot, is speculative taxonomy — don't create it.
+
+### Structure rules
+
+- **Two-storey where the system owns the curve** — ramps beneath (const vocabulary), themeable semantics above. Applies to text and space. Colour is hue-seeded instead — no shared palette beneath the scales.
+- **Scheme (dark/light) is a facet of values**, not a theme: scheme-affected groups (colour, materials) hold per-scheme values in one entry. Dark is the only authored scheme for now; light is an empty seat at a set table — addable without structural change. Call sites never scheme-switch (see the derivation pairs below).
+- **Scoped application** — a theme applies to a subtree, not only a root. Local pitch (a Card re-pitching spacing for its children) is scoped theming over the one schema, never a second scale.
+
+## Colour
+
+**Every colour is OKLCH** — `oklch(L C H / α)`. Format law, all strata.
+
+### Scale anatomy
+
+Identical across flavour and status scales. Bands are sub-group vocabulary; fg/bg hue-divergence within a scale is a values freedom.
+
+| band | members | job |
+|---|---|---|
+| **fill** | `subtle` · `fill` | component backgrounds, quiet → emphatic. `fill` takes the seed directly (Default); deviate only when the `fill`×`onFill` AA pairing forces it |
+| **edge** | `border` (recedes) · `line` (advances) | boundaries between layers |
+| **marks** | `ink` · `inkSecondary` · `inkTertiary` · `icon` · `onFill` · `onFillSecondary` | foreground content; `icon` sits below `ink` to optically match |
+| **materials** | `trace` · `glow` — growable | what colour a material effect is in this hue; the physics live in Materials |
+
+### Roster
+
+- **Flavour**: `accent` · `neutral`. `complementary` is deferred — watch for accent-overload deviations (cross-scale borrows, accent fatigue in dense screens) as the evidence that earns it.
+- **Status**: `positive` · `warning` · `danger`. No `info` — that job belongs to `accent`/`neutral` until evidence says otherwise.
+- **`surface`** — the neutral planes. Anatomy deferred to the Layers area: its slots are the layer model wearing colour.
+- Extension is implicit: shipped components conform to this contract; consumers extend it or build adjacent contracts freely.
+
+### Static category
+
+Scale-less app-wide singletons, themeable like any group: `white` · `black` · `disabledInk` · `disabledFill` · `focus`. Disabled is cross-scale by nature (all scales converge on one greyed pair); `focus` is the app-wide focus-ring colour. `currentColor` is CSS machinery, not a token.
+
+### Derivation pairs
+
+| pair | nature | use |
+|---|---|---|
+| `shade` / `tint` | physical, **scheme-invariant**, const ramps of black/white alpha as full colours (for `color-mix`) | absolute darkening/lightening: scrims, shadows, over-media legibility floors |
+| `advance` / `recede` | semantic, **scheme-variant** (advance = shade in light, tint in dark) | all emphasis derivations: hover washes, press moves, selected lifts |
+
+Emphasis via the physical pair is a deviation — it bakes a scheme assumption into the call site.
+
+Parked: the semantic colour-alias layer — cross-scale borrow deviations are the evidence that will earn it.
+
+## Materials
+
+Two materials, defined by how a surface handles light, plus an orthogonal **emission dial** (radiates; composes with both). Emissive-as-third-material waits for a specimen `solid` at max emission can't express.
+
+| property | `solid` (reflects) | `glass` (transmits) |
+|---|---|---|
+| backdrop | blocked | transmitted: blur + tint; scrim/opacity floor guarantees marks-band AA over **any** backdrop |
+| legibility mechanism | `fill`×`onFill` pairing | the scrim floor — the arbitrary-backdrop contract lives here and only here |
+| grain/texture | allowed, quiet | allowed, quiet |
+| emission | dial, off by default | dial, off by default |
+| reduced-transparency | no-op | collapses toward solid — defined once, here |
+
+- Every component that owns a surface has a material — containers lean glass, controls lean solid; marks never have one. Exposed as a prop where the choice is legitimate.
+- Emission colour comes from the scale's `glow` member; gradients/cores derive via `color-mix` with seed/fill at authoring time. Derived values land as authored group values — no runtime identity math.
+- Grain/texture: slots for asset, density, opacity; colour-agnostic masks over token colour; specifics discovered in labs (masking also serves emissive surfaces).
+- The group anatomy for `solid` / `glass` / the emission dial — which vars each carries (blur, tint, scrim floor, emission levels) — is **unresolved**; tracked as an open slot in [[theme-contract]].
+
+### Interaction states
+
+- **Interactivity is a class property of the component, never per-instance.** Non-interactive components have no state styling.
+- **Gesture union** (exclusive): `default | hover | press | disabled` — `press`, never `active` (nav-current collision). Disabled suppresses the others.
+- **Additive booleans**: `selected` (a persistent mode — coexists with gestures and disabled) and `focus` (`focus-visible` semantics; composes with everything).
+- **Focus is structural**: a ring drawn from `static.focus`, never an emission level — glow may garnish a focus ring, never be it. Token home (ring width/offset) deferred to the component-category area.
+- Emission-maps-to-states (hover → ambient, press → hot) is a **flagship leaning**, not a contract binding: panels may run ambient emission as atmosphere; solid controls may have crisp no-emission states.
+
+## Shape
+
+Two deformation types, by perimeter site; a silhouette is a base rect plus deformations. **Radius is not a concept** — the rounded world is chamfers with `round` profile.
+
+| type | site | properties |
+|---|---|---|
+| **chamfer** | corner | position (corners/sets) · size (depth ramp) · optional asymmetric legs · **one** profile — a chamfer is a single-gesture cut |
+| **notch** | edge | position (edge + placement) · width × depth (ratio is the aspect; `slot` = narrow×deep preset) · wall · profile **per end** |
+
+- **Tokenised**: the shared **depth ramp** (a few absolute px steps — one tool, one machining vocabulary) and the **profile vocabulary** (`square · straight · round`).
+- **Site-owned**: which elements carry which deformations, where, at what aspect — design decisions, never theme-global. Named presets record recurring recipes, earned not speculative.
+- **Mechanism**: the polygon generator and rendering (clip-path + SVG stroke + drop-shadow halo) are code, not tokens.
+- **Contract invariants**: the bounding box is never exceeded (shape never disturbs spacing, under any theme); min width/height must exceed the cut size.
+- Accepted consequence: de-cyberpunking geometry is per-site work, not a one-line theme edit.
+
+## Text
+
+**Leading-trim is a contract law** — `text-box-trim` applied globally; a font's box equals its ink, so every gap and inset around text is optical. Spacing values are tuned to the trimmed rendering; the untrimmed fallback (Firefox, today) degrades gracefully looser.
+
+**Two scales.** The classification rule: *text balances against its environment (UI) or against itself (editorial).* An error message balances against its field → UI; long-form you actually read → editorial.
+
+| scale | shape | roles |
+|---|---|---|
+| **UI** | t-shirt ramp `xs · sm · md · lg · xl` (`md` = 16px/1rem, the shared anchor) + thin semantic roles | `heading` · `subheading` · `label` · `action` — growable |
+| **editorial** | role-first, ramp hidden; generous leading; big differentiation | `display` · `heading` · `subheading` · `kicker` · `lede` · `body` · `mono` · `caption` — growable |
+
+- `heading` exists in both scales and is never shared — a panel heading is wayfinding chrome; an article heading is typographic architecture.
+- The duty taxonomy (announce / read / data) survives as classification guidance — the test an agent applies when placing a new role — not as mechanical structure.
+
+## Space
+
+- **UI spacing**: `gap` (between items) and `inset` (content → edge) over the shared t-shirt ramp. Margin folds in — margin-to-edge is inset, margin-between is gap; a raw margin is a deviation. Width/height are excluded (control sizing belongs to the component-category area).
+- **Editorial layout is its own subsystem** — the relatedness grammar (`cluster / hug / group / section`) and the recursive container grammar (`header? · body · footer?`) live there, opted into for genuine long-form.
+- Kept as a UI-side rule: **a header sits tighter to its content than peers sit to each other** — the one spacing relationship that keeps headed structure legible at any density.
+- `inset` level naming deferred until the Layers area settles.
+
+## The size vocabulary
+
+`xs · sm · md · lg · xl` is **one coordinated size-world** across UI text, spacing, and control sizes — a `sm` control wants a `sm` label and `sm` gaps. The coordination contract gets defined with the component-category groups.
+
+## Open threads
+
+Tracked as beads; owned by future sessions or earned by evidence:
+
+- **Layers** — the planes/layer model, `surface` scale anatomy, `inset` level names
+- **Component-category groups** — control sizes, content widths, focus-ring tokens, the t-shirt coordination contract
+- **Motion** — the missing axis; `prefers-reduced-motion` is already law ([[product-framing]])
+- Semantic colour-alias layer (earned by borrow deviations) · `complementary` (earned by accent overload) · emissive-as-material (earned by specimen) · container-grammar componentization

--- a/docs/knowledge/theme-guidelines.md
+++ b/docs/knowledge/theme-guidelines.md
@@ -127,7 +127,16 @@ Two deformation types, by perimeter site; a silhouette is a base rect plus defor
 - **UI spacing**: `gap` (between items) and `inset` (content → edge) over the shared t-shirt ramp. Margin folds in — margin-to-edge is inset, margin-between is gap; a raw margin is a deviation. Width/height are excluded (control sizing belongs to the component-category area).
 - **Editorial layout is its own subsystem** — the relatedness grammar (`cluster / hug / group / section`) and the recursive container grammar (`header? · body · footer?`) live there, opted into for genuine long-form.
 - Kept as a UI-side rule: **a header sits tighter to its content than peers sit to each other** — the one spacing relationship that keeps headed structure legible at any density.
-- `inset` level naming deferred until the Layers area settles.
+- Both semantic trios (`plane · container · control`) key to the layer model below. Inset's is near-definitive (containment is intrinsic to a layer); gap's is a **defaults layer** — between-ness varies by relatedness within a layer, so the raw ramp refines below the defaults.
+
+## Layers
+
+The plane/layer model — design-language stratum, carried from the poc:
+
+- A **plane** is a stacking context holding four layers. The app is the root plane; modals, popovers, menus open **child planes** — modality is never a special layer. A **modal** child plane recedes its parent down the contrast axis; non-modal child planes (tooltips, menus) don't. The scrim is just the modal child plane's backdrop doing the recession — assembled from existing vocabulary (`shade`, material blur), no modal-specific machinery. Cross-plane stacking is one portal/ordering policy: no z-index arms races.
+- Within a plane, four **layers**, back to front: **backdrop** (contextual ground — solid, image, game viewport, or scrim-over-receded-parent) → **containers** → **controls** → **marks**. Roles, not z-order.
+- The model is the agent decision table: a component's layer role answers its material lean (containers→glass, controls→solid), its inset level, its contrast defaults ("loudness climbs the layers"), and its colour-band usage.
+- **Surface derives from it**: `canvas`/`panel`/`raised` are the ramp band (jobs, not a lightness ladder — a theme may pitch panels below canvas, the Apple "grouped" inversion, and both pitches can coexist via scoped themes); `overlay`/`scrim` are the plane band (a different plane's face and the recession backdrop — related, not on the ramp). Container nesting caps at `raised` — needing a third depth is the over-nesting signal, same as the heading ladder. Deep glass nesting differentiates by transmission anyway; the members anchor the solid/matte case.
 
 ## The size vocabulary
 
@@ -137,7 +146,6 @@ Two deformation types, by perimeter site; a silhouette is a base rect plus defor
 
 Tracked as beads; owned by future sessions or earned by evidence:
 
-- **Layers** — the planes/layer model, `surface` scale anatomy, `inset` level names
 - **Component-category groups** — control sizes, content widths, focus-ring tokens, the t-shirt coordination contract
 - **Motion** — the missing axis; `prefers-reduced-motion` is already law ([[product-framing]])
 - Semantic colour-alias layer (earned by borrow deviations) · `complementary` (earned by accent overload) · emissive-as-material (earned by specimen) · container-grammar componentization

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,58 @@
+---
+tags: [index, rules]
+---
+
+# Rules
+
+Entrypoint for the design-language rule register: a flat, evidence-based collection, one file per rule under `docs/rules/`. The model behind it — strata, strictness, the deviation format — lives in [[design-language]]. Add rules with the `rule` skill as violations are discovered; removal is deliberate and rare.
+
+Cite rules at deviation sites: `// deviation(<slug>): <reason>`.
+
+## Contract
+
+Mechanical, neutral — enforced by the machinery itself.
+
+| rule | |
+|---|---|
+| [[oklch-only]] | every colour is `oklch(L C H / α)` — the perceptual space all colour reasoning assumes |
+| [[tokens-are-spec]] | tokens are implementation-independent; CSS vars/JS/conventions are carriers |
+| [[leading-trim]] | all text is leading-trimmed; spacing is tuned against the trimmed rendering |
+| [[silhouette-bounding-box]] | a silhouette never exceeds its box; shape never disturbs spacing |
+| [[cut-min-size]] | an element must exceed its cut size — a cut can never eat its element |
+| [[empirical-categories]] | categories are earned by visible clustering + co-movement, never declared |
+| [[no-scheme-switch]] | call sites never branch on scheme; semantic tokens carry the flip |
+| [[fill-takes-seed]] | `fill` is the seed directly, unless the AA pairing forces adjustment |
+| [[authored-derivation]] | derivation is an authoring tool; results land as authored values |
+
+## Language
+
+Opinionated grammar, theme-agnostic — agent-followed, review-enforced.
+
+| rule | |
+|---|---|
+| [[contrast-floor]] | AA is the floor for functional content, guaranteed by the material |
+| [[flair-never-sole-carrier]] | flair garnishes meaning, never carries it alone |
+| [[interactivity-is-class]] | a component is interactive or it isn't — never per-instance |
+| [[state-grammar]] | gestures `default·hover·press·disabled`; `selected`/`focus` additive; no `active` |
+| [[structural-focus]] | focus is a `static.focus` ring; emission never substitutes |
+| [[browser-cursor]] | the browser sets the cursor; never fake `pointer` |
+| [[text-balance]] | text balancing its environment → UI scale; itself → editorial |
+| [[emphasis-pair]] | emphasis uses `advance`/`recede`; `shade`/`tint` are physical only |
+| [[header-proximity]] | a header sits tighter to its content than peers sit to each other |
+| [[no-margin]] | spacing is padding + `gap`; margin is a deviation |
+| [[shape-site-owned]] | geometry application is a site decision, never theme-global |
+| [[chamfer-single-gesture]] | one profile per chamfer; notches take a profile per end |
+| [[composed-constructable]] | composed components are convenience, never capability |
+| [[shade-tint-derive-only]] | the physical pairs derive; they are not surface/ink colours |
+
+## Flagship
+
+The cyberpunk identity — value-level laws; other themes deviate freely.
+
+| rule | |
+|---|---|
+| [[square-baseline]] | the square is the baseline; cuts over rounding; avatars stand deviant |
+| [[cut-must-host]] | every cut hosts something — light counts; garnish fails |
+| [[emissive-states]] | things light up under the hand: hover → ambient, press → hot |
+| [[hue-emphasis]] | emphasis advances by hue, not weight (scope under observation in prose) |
+| [[machined-texture]] | texture is an abstracted machined motif, never a picture |

--- a/docs/rules/authored-derivation.md
+++ b/docs/rules/authored-derivation.md
@@ -1,0 +1,27 @@
+---
+slug: authored-derivation
+stratum: contract
+strictness: default
+---
+
+# authored-derivation
+
+Derived colour values (`color-mix`, curve transforms) are authoring tools; results SHOULD land as authored group values, not runtime dependencies.
+
+## Rationale
+
+Group completeness is the coherence guarantee — a theme's identity must not depend on runtime math whose output nobody reviewed. Deriving (a glow gradient mixed from `glow` and `fill`, a first-draft light scheme transformed from dark) is encouraged at authoring time; the derived value is then committed, reviewable, and tunable by eye.
+
+## Examples
+
+### Incorrect
+
+A component computing its hover wash at runtime from arbitrary inputs.
+
+### Correct
+
+A lab route deriving candidate values; the chosen result written into the group.
+
+## Evidence
+
+Recorded at founding (urban-ui-727), from the glow-gradient and light-scheme-derivation discussions.

--- a/docs/rules/authored-derivation.md
+++ b/docs/rules/authored-derivation.md
@@ -2,6 +2,7 @@
 slug: authored-derivation
 stratum: contract
 strictness: default
+enforcement: review
 ---
 
 # authored-derivation
@@ -12,11 +13,13 @@ Derived colour values (`color-mix`, curve transforms) are authoring tools; resul
 
 Group completeness is the coherence guarantee — a theme's identity must not depend on runtime math whose output nobody reviewed. Deriving (a glow gradient mixed from `glow` and `fill`, a first-draft light scheme transformed from dark) is encouraged at authoring time; the derived value is then committed, reviewable, and tunable by eye.
 
+This rule targets *novel values* computed from arbitrary inputs. A runtime `color-mix` over semantic tokens at a call site — an emphasis wash per [[emphasis-pair]], a scrim assembled per [[shade-tint-derive-only]] — is not a derivation in this sense: those mixes *are* the sanctioned grammar, every input is a governed token, and the recipe itself is the reviewed artifact.
+
 ## Examples
 
 ### Incorrect
 
-A component computing its hover wash at runtime from arbitrary inputs.
+A component curve-transforming the raw seed at runtime to invent a wash colour no group ever declared.
 
 ### Correct
 

--- a/docs/rules/browser-cursor.md
+++ b/docs/rules/browser-cursor.md
@@ -2,6 +2,7 @@
 slug: browser-cursor
 stratum: language
 strictness: law
+enforcement: machine
 ---
 
 # browser-cursor

--- a/docs/rules/browser-cursor.md
+++ b/docs/rules/browser-cursor.md
@@ -1,0 +1,29 @@
+---
+slug: browser-cursor
+stratum: language
+strictness: law
+---
+
+# browser-cursor
+
+Let the browser set the cursor. Links show `pointer` natively; buttons show the default arrow. `cursor: pointer` MUST NOT be set manually.
+
+## Rationale
+
+Pointer means *navigates*, and only links navigate. A control that makes you reach for `cursor: pointer` is mis-built (probably a link wearing a button, or vice versa) — fix the control, not the cursor. Non-pointer state cursors (`not-allowed` on a disabled control, resize handles) are fine; the ban is on faking `pointer`.
+
+## Examples
+
+### Incorrect
+
+```ts
+cursor: "pointer"   // on a <button>
+```
+
+### Correct
+
+`<a href>` for navigation (pointer for free); `<button>` for actions (arrow, correctly).
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk where it was already Law.

--- a/docs/rules/chamfer-single-gesture.md
+++ b/docs/rules/chamfer-single-gesture.md
@@ -2,6 +2,7 @@
 slug: chamfer-single-gesture
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # chamfer-single-gesture

--- a/docs/rules/chamfer-single-gesture.md
+++ b/docs/rules/chamfer-single-gesture.md
@@ -1,0 +1,27 @@
+---
+slug: chamfer-single-gesture
+stratum: language
+strictness: default
+---
+
+# chamfer-single-gesture
+
+A chamfer is a single-gesture cut: one profile per corner, no mixed leg character.
+
+## Rationale
+
+A 60/30 leg pair or a hard 45° running into a rounded exit reads as two decisions occupying one corner — visual noise, not vocabulary. Asymmetric legs (expressed as lengths) are permitted; mixed *character* is not. Notches differ: a notch has two ends and specifies profile per end, because a cut can legitimately enter squared and exit rounded.
+
+## Examples
+
+### Incorrect
+
+A corner cut that is half straight, half arc.
+
+### Correct
+
+`chamfer(size: depth.sm, profile: round)` — one gesture, applied whole.
+
+## Evidence
+
+Recorded at founding (urban-ui-727), from the geometry deformation discussion.

--- a/docs/rules/composed-constructable.md
+++ b/docs/rules/composed-constructable.md
@@ -1,0 +1,27 @@
+---
+slug: composed-constructable
+stratum: language
+strictness: default
+---
+
+# composed-constructable
+
+Every composed component MUST be constructable by consumers from primitives and the design language — composed is convenience, never capability.
+
+## Rationale
+
+If a composed component can't be rebuilt from the documented system, the primitive layer has a gap — the composed tier was hiding it. The construction path has to be documented anyway (agents-first docs), which keeps the composed tier small and honest: it ships recurrence and behavioural complexity, not secret powers.
+
+## Examples
+
+### Incorrect
+
+A command palette relying on private internals no consumer could reach.
+
+### Correct
+
+The shipped command palette as a documented composition of overlay, input, and list primitives.
+
+## Evidence
+
+Session-1 Decision 8 ([[product-framing]]).

--- a/docs/rules/composed-constructable.md
+++ b/docs/rules/composed-constructable.md
@@ -2,6 +2,7 @@
 slug: composed-constructable
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # composed-constructable

--- a/docs/rules/contrast-floor.md
+++ b/docs/rules/contrast-floor.md
@@ -1,0 +1,27 @@
+---
+slug: contrast-floor
+stratum: language
+strictness: law
+---
+
+# contrast-floor
+
+WCAG AA contrast is the floor for functional content — text, controls, focus indicators — and it is the material's job to guarantee it.
+
+## Rationale
+
+Materials are where legibility is decided: `solid` guarantees via the `fill`×`onFill` pairing; `glass` via its scrim/opacity floor over arbitrary backdrops. Making the guarantee a material property turns per-component contrast review into a checkable token-level contract — which matters when reviewers are agents who can verify a stated number but can't eyeball "is this readable".
+
+## Examples
+
+### Incorrect
+
+A glass panel whose legibility depends on the page behind it happening to be dark.
+
+### Correct
+
+Glass carrying a scrim floor that holds marks-band AA over a worst-case backdrop.
+
+## Evidence
+
+Session-1 Decision 6 ([[product-framing]]); mechanised in urban-ui-727.

--- a/docs/rules/contrast-floor.md
+++ b/docs/rules/contrast-floor.md
@@ -2,6 +2,7 @@
 slug: contrast-floor
 stratum: language
 strictness: law
+enforcement: machine
 ---
 
 # contrast-floor

--- a/docs/rules/cut-min-size.md
+++ b/docs/rules/cut-min-size.md
@@ -2,6 +2,7 @@
 slug: cut-min-size
 stratum: contract
 strictness: law
+enforcement: machine
 ---
 
 # cut-min-size

--- a/docs/rules/cut-min-size.md
+++ b/docs/rules/cut-min-size.md
@@ -1,0 +1,27 @@
+---
+slug: cut-min-size
+stratum: contract
+strictness: law
+---
+
+# cut-min-size
+
+An element's minimum width and height MUST exceed its cut size — a cut can never eat its element.
+
+## Rationale
+
+Deformation sizes come from the shared `depth` ramp; elements scale independently. Without the guardrail, a small element with a standard cut degenerates (self-intersecting polygons, vanished fill). The generator should enforce this, not just document it.
+
+## Examples
+
+### Incorrect
+
+A 12px icon-button carrying a 16px chamfer.
+
+### Correct
+
+The same button clamped to the smallest depth step that fits, or shipped square.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk geometry laws.

--- a/docs/rules/cut-must-host.md
+++ b/docs/rules/cut-must-host.md
@@ -2,6 +2,7 @@
 slug: cut-must-host
 stratum: flagship
 strictness: law
+enforcement: review
 ---
 
 # cut-must-host

--- a/docs/rules/cut-must-host.md
+++ b/docs/rules/cut-must-host.md
@@ -1,0 +1,27 @@
+---
+slug: cut-must-host
+stratum: flagship
+strictness: law
+---
+
+# cut-must-host
+
+A cut's job is to host. Every cut answers "what does it host?" — an emissive status, pooled glow, a control seated in the aperture. "Nothing, it looks good" fails the test.
+
+## Rationale
+
+A cut is a machined socket the other axes fill, never decoration. Hosting the light itself counts — a chamfer catching the halo *is* hosting; only a cut that hosts neither occupant nor light is garnish. This keeps the geometry vocabulary functional as it grows: new silhouettes are earned by host-needs, not invented for variety.
+
+## Examples
+
+### Incorrect
+
+A serrated edge run added "for texture" (dense repetition is material's job anyway).
+
+### Correct
+
+A notch seating a status LED; a chamfer pooling the panel's glow.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk geometry laws.

--- a/docs/rules/emissive-states.md
+++ b/docs/rules/emissive-states.md
@@ -1,0 +1,27 @@
+---
+slug: emissive-states
+stratum: flagship
+strictness: default
+---
+
+# emissive-states
+
+Things light up under the hand: hover leans toward ambient emission, press toward hot. A leaning of the identity, not a state-grammar binding.
+
+## Rationale
+
+The flagship's state feel — interaction reads as energising the element rather than darkening it. Deliberately not a contract rule: emission is a material dial any surface may use for pure atmosphere (an ambient non-interactive panel), and a solid control may run crisp no-emission states. Deviate freely where the composition wants it; the identity emerges from the default, not from enforcement.
+
+## Examples
+
+### Correct (flagship default)
+
+Button: `default` no emission → `hover` ambient → `press` hot.
+
+### Also correct (deviation not required)
+
+A quiet toolbar whose buttons state-change by fill only.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); demoted from a proposed 1:1 state↔emission mapping during the interview.

--- a/docs/rules/emissive-states.md
+++ b/docs/rules/emissive-states.md
@@ -1,7 +1,8 @@
 ---
 slug: emissive-states
 stratum: flagship
-strictness: default
+strictness: leaning
+enforcement: judgment
 ---
 
 # emissive-states

--- a/docs/rules/emphasis-pair.md
+++ b/docs/rules/emphasis-pair.md
@@ -1,0 +1,31 @@
+---
+slug: emphasis-pair
+stratum: language
+strictness: default
+---
+
+# emphasis-pair
+
+Emphasis derivations (hover washes, press moves, selected lifts) use `advance`/`recede`; the physical pair (`shade`/`tint`) is for absolute darkening/lightening only.
+
+## Rationale
+
+Emphasis moves against the scheme's ground — what darkens in light mode lightens in dark mode — and `advance`/`recede` carry that flip in their scheme-faceted values. `shade`/`tint` are scheme-invariant by design: scrims, shadows, and over-media legibility floors darken in any scheme. Using the physical pair for emphasis bakes today's dark-mode assumption into the call site (see [[no-scheme-switch]]).
+
+## Examples
+
+### Incorrect
+
+```ts
+backgroundColor: `color-mix(in oklch, ${fill}, ${tint._300})`  // hover wash
+```
+
+### Correct
+
+```ts
+backgroundColor: `color-mix(in oklch, ${fill}, ${advance._300})`
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727), resolving the shade/tint scheme-variance question.

--- a/docs/rules/emphasis-pair.md
+++ b/docs/rules/emphasis-pair.md
@@ -2,6 +2,7 @@
 slug: emphasis-pair
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # emphasis-pair

--- a/docs/rules/empirical-categories.md
+++ b/docs/rules/empirical-categories.md
@@ -1,0 +1,27 @@
+---
+slug: empirical-categories
+stratum: contract
+strictness: law
+---
+
+# empirical-categories
+
+A category is created only on evidence: its groups MUST visibly cluster in value-space AND move together under real edits. Speculative taxonomy is not created.
+
+## Rationale
+
+Categories exist to make bigger coherent swaps safe (re-hue, re-pitch, re-voice). A category nobody edits as one, invisible on a plot, is indirection with no coherence payoff — and it can't be falsified. Co-movement is the membership test; when a group keeps getting edited apart from its category, the category is drawn wrong.
+
+## Examples
+
+### Incorrect
+
+Creating a `complementary` flavour scale before a concrete use exists.
+
+### Correct
+
+The status category: three scales rendering as near-identical L/C curves differing only in hue, retuned as one when "status colours are too loud".
+
+## Evidence
+
+Recorded at founding (urban-ui-727); the flavour/status distinction visible in curve-space was the motivating case.

--- a/docs/rules/empirical-categories.md
+++ b/docs/rules/empirical-categories.md
@@ -2,6 +2,7 @@
 slug: empirical-categories
 stratum: contract
 strictness: law
+enforcement: review
 ---
 
 # empirical-categories

--- a/docs/rules/fill-takes-seed.md
+++ b/docs/rules/fill-takes-seed.md
@@ -2,6 +2,7 @@
 slug: fill-takes-seed
 stratum: contract
 strictness: default
+enforcement: machine
 ---
 
 # fill-takes-seed

--- a/docs/rules/fill-takes-seed.md
+++ b/docs/rules/fill-takes-seed.md
@@ -1,0 +1,29 @@
+---
+slug: fill-takes-seed
+stratum: contract
+strictness: default
+---
+
+# fill-takes-seed
+
+A colour scale's `fill` SHOULD be its seed colour directly; deviate only when the `fill`×`onFill` AA pairing forces an adjustment.
+
+## Rationale
+
+The seed is what you say when you pick an identity ("the accent is cyan"); fill is the scale's loudest self-expression. Coinciding keeps the re-hue move maximally legible: set seed, fill *is* it, everything else derives around it. The contrast guarantee outranks seed purity — the classic yellow problem, where the pure seed cannot hold AA against any onFill.
+
+## Examples
+
+### Correct
+
+Accent seeded cyan; `accent.fill` is that cyan.
+
+### Sanctioned deviation
+
+```
+// deviation(fill-takes-seed): seed L too high for AA onFill; fill darkened one step
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727).

--- a/docs/rules/flair-never-sole-carrier.md
+++ b/docs/rules/flair-never-sole-carrier.md
@@ -2,6 +2,7 @@
 slug: flair-never-sole-carrier
 stratum: language
 strictness: law
+enforcement: review
 ---
 
 # flair-never-sole-carrier

--- a/docs/rules/flair-never-sole-carrier.md
+++ b/docs/rules/flair-never-sole-carrier.md
@@ -1,0 +1,27 @@
+---
+slug: flair-never-sole-carrier
+stratum: language
+strictness: law
+---
+
+# flair-never-sole-carrier
+
+Flair MUST NOT be the only carrier of meaning: a glow may accent a state, never be its sole indicator.
+
+## Rationale
+
+Glows, materials, and emission die under reduced-transparency, reduced-motion, and hostile backdrops — meaning must survive their removal. Flair garnishes a structural signal (a ring, a fill change, an icon), it never replaces one.
+
+## Examples
+
+### Incorrect
+
+Focus indicated only by an emission increase.
+
+### Correct
+
+Focus as a `static.focus` ring; glow optionally haloing it.
+
+## Evidence
+
+Session-1 Decision 6 ([[product-framing]]).

--- a/docs/rules/header-proximity.md
+++ b/docs/rules/header-proximity.md
@@ -2,6 +2,7 @@
 slug: header-proximity
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # header-proximity

--- a/docs/rules/header-proximity.md
+++ b/docs/rules/header-proximity.md
@@ -1,0 +1,27 @@
+---
+slug: header-proximity
+stratum: language
+strictness: default
+---
+
+# header-proximity
+
+A header sits tighter to the content it heads than peers sit to each other, at any density.
+
+## Rationale
+
+Grouping is a contrast of gaps. If the gap above a heading equals the gap below it, the heading floats between blocks instead of belonging to one — the single spacing relationship that makes headed structure legible without rules or boxes, from a dense settings panel to an article. Leading-trim makes these distances optical, so the relationship renders as stated.
+
+## Examples
+
+### Incorrect
+
+Uniform `gap: md` around a section title.
+
+### Correct
+
+Title-to-content one step tighter than section-to-section.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); the surviving core of the poc's relatedness grammar (`hug < group`).

--- a/docs/rules/hue-emphasis.md
+++ b/docs/rules/hue-emphasis.md
@@ -1,0 +1,33 @@
+---
+slug: hue-emphasis
+stratum: flagship
+strictness: default
+---
+
+# hue-emphasis
+
+Emphasis advances by hue, not weight: to stress a span, lift it into the accent ink rather than bolding it.
+
+## Rationale
+
+Weight stays the role's to set; emphasis borrows the contrast axis — "louder" said in the language's own terms. Bolding running prose also fights leading-trim's optical spacing.
+
+**Scope under observation:** in long-form prose, accent-hued spans can read as links. A deviation tally here may earn the read/editorial context a written exemption — this is the register's canonical example of a rule whose scope is being tested by evidence.
+
+## Examples
+
+### Incorrect (flagship default)
+
+```tsx
+<strong>overdue</strong>
+```
+
+### Correct
+
+```tsx
+<em {...stylex.props(emphasis.accent)}>overdue</em>
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk, scope question raised during the interview.

--- a/docs/rules/hue-emphasis.md
+++ b/docs/rules/hue-emphasis.md
@@ -2,6 +2,7 @@
 slug: hue-emphasis
 stratum: flagship
 strictness: default
+enforcement: review
 ---
 
 # hue-emphasis

--- a/docs/rules/interactivity-is-class.md
+++ b/docs/rules/interactivity-is-class.md
@@ -2,6 +2,7 @@
 slug: interactivity-is-class
 stratum: language
 strictness: law
+enforcement: review
 ---
 
 # interactivity-is-class

--- a/docs/rules/interactivity-is-class.md
+++ b/docs/rules/interactivity-is-class.md
@@ -1,0 +1,27 @@
+---
+slug: interactivity-is-class
+stratum: language
+strictness: law
+---
+
+# interactivity-is-class
+
+A component is interactive or it is not — interactivity is a class property of the component, never a per-instance styling choice.
+
+## Rationale
+
+Interactive affordance is a promise to the user. A Panel that hovers in one screen and not another teaches users nothing reliable, and lets agents sprinkle affordance where no behaviour exists. Non-interactive components carry no state styling at all.
+
+## Examples
+
+### Incorrect
+
+Adding a hover treatment to a static Panel "for liveliness".
+
+### Correct
+
+Wrapping content in an interactive primitive when it genuinely acts; the Panel itself stays inert.
+
+## Evidence
+
+Recorded at founding (urban-ui-727), stated during the interaction-state discussion.

--- a/docs/rules/leading-trim.md
+++ b/docs/rules/leading-trim.md
@@ -1,0 +1,29 @@
+---
+slug: leading-trim
+stratum: contract
+strictness: law
+---
+
+# leading-trim
+
+All text is leading-trimmed (`text-box-trim`); spacing values MUST be tuned against the trimmed rendering.
+
+## Rationale
+
+Trimming makes a font's box equal its ink, so every gap and inset around text is optical — a 16px gap is 16px of visible whitespace. Control heights become honest, headers seat on their content, and the spacing scales mean what they say. Untrimming later re-pitches every spacing value in every theme.
+
+Ships in the `base` layer of the theme package's global CSS. The untrimmed fallback (Firefox, currently) degrades gracefully looser.
+
+## Examples
+
+### Incorrect
+
+Compensating for phantom leading with asymmetric padding on a control.
+
+### Correct
+
+Symmetric padding from the `inset` scale; the trim guarantees it renders symmetric.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk where the relatedness grammar depends on it.

--- a/docs/rules/leading-trim.md
+++ b/docs/rules/leading-trim.md
@@ -2,6 +2,7 @@
 slug: leading-trim
 stratum: contract
 strictness: law
+enforcement: machine
 ---
 
 # leading-trim

--- a/docs/rules/machined-texture.md
+++ b/docs/rules/machined-texture.md
@@ -2,6 +2,7 @@
 slug: machined-texture
 stratum: flagship
 strictness: leaning
+enforcement: judgment
 ---
 
 # machined-texture

--- a/docs/rules/machined-texture.md
+++ b/docs/rules/machined-texture.md
@@ -1,0 +1,27 @@
+---
+slug: machined-texture
+stratum: flagship
+strictness: leaning
+---
+
+# machined-texture
+
+Texture is an abstracted machined motif, never a picture. Dense repetition crosses into a noise field.
+
+## Rationale
+
+A textured surface keeps the grammar of its referent (orthogonal circuit routing, square vias) without the literal image — recognisable boards and silkscreen are skeuomorphic and fight the hard-machined vocabulary. Texture sits quiet (the `trace` colour role) as ambient material, not a mark to parse; assets are colour-agnostic masks over token colour so they re-hue with the theme. Specifics (density, scale, glitch treatments) are lab work.
+
+## Examples
+
+### Incorrect
+
+A photographic PCB as a panel background.
+
+### Correct
+
+An abstract orthogonal trace mask at `trace` opacity.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk material leanings.

--- a/docs/rules/no-margin.md
+++ b/docs/rules/no-margin.md
@@ -2,6 +2,7 @@
 slug: no-margin
 stratum: language
 strictness: default
+enforcement: machine
 ---
 
 # no-margin

--- a/docs/rules/no-margin.md
+++ b/docs/rules/no-margin.md
@@ -1,0 +1,37 @@
+---
+slug: no-margin
+stratum: language
+strictness: default
+---
+
+# no-margin
+
+Spacing comes from padding and `gap`; margin MUST NOT be used.
+
+## Rationale
+
+Margin collapse is context-dependent — margins collapse in flow layout and don't in flex/grid — so the same value reads differently per container. Padding and gap compose predictably everywhere. Leading-trim removes the phantom leading that margins historically compensated for; to-edge spacing is `inset` (padding), between spacing is `gap`.
+
+## Examples
+
+### Incorrect
+
+```ts
+marginBlockStart: space.md
+```
+
+### Correct
+
+```ts
+gap: space.md   // on the parent
+```
+
+### Sanctioned deviation
+
+```
+// deviation(no-margin): third-party embed injects sibling flow content
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727); margin-collapse confusion across prior iterations. Supersedes the softer "margin folds into the scales" phrasing.

--- a/docs/rules/no-scheme-switch.md
+++ b/docs/rules/no-scheme-switch.md
@@ -1,0 +1,31 @@
+---
+slug: no-scheme-switch
+stratum: contract
+strictness: law
+---
+
+# no-scheme-switch
+
+Call sites MUST NOT branch on colour scheme. A derivation that flips with scheme is a semantic token (`advance`/`recede`) whose per-scheme values do the flipping.
+
+## Rationale
+
+Scheme is a facet of token values, not a component concern. A component that switches shade/tint on dark mode bakes a scheme assumption into every call site — the migration debt "scheme in the contract from day one" exists to prevent. Dark is the only authored scheme today; call sites written against semantic tokens survive light's arrival untouched.
+
+## Examples
+
+### Incorrect
+
+```ts
+backgroundColor: isDark ? tint._300 : shade._300
+```
+
+### Correct
+
+```ts
+backgroundColor: recede._300   // values are scheme-faceted
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727), resolving the shade/tint scheme-variance question.

--- a/docs/rules/no-scheme-switch.md
+++ b/docs/rules/no-scheme-switch.md
@@ -2,6 +2,7 @@
 slug: no-scheme-switch
 stratum: contract
 strictness: law
+enforcement: machine
 ---
 
 # no-scheme-switch

--- a/docs/rules/oklch-only.md
+++ b/docs/rules/oklch-only.md
@@ -1,0 +1,31 @@
+---
+slug: oklch-only
+stratum: contract
+strictness: law
+---
+
+# oklch-only
+
+Every colour MUST be declared in OKLCH — `oklch(L C H)` or `oklch(L C H / α)`.
+
+## Rationale
+
+The system's colour reasoning is perceptual: scale curves, band relationships, equi-perceptual status hues, and the empirical category test all assume a space where L/C/H moves mean what they say. A hex or HSL value is illegible to that machinery.
+
+## Examples
+
+### Incorrect
+
+```ts
+fill: "#4f46e5"
+```
+
+### Correct
+
+```ts
+fill: "oklch(0.51 0.23 275)"
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from the poc-cyberpunk colour rules.

--- a/docs/rules/oklch-only.md
+++ b/docs/rules/oklch-only.md
@@ -2,6 +2,7 @@
 slug: oklch-only
 stratum: contract
 strictness: law
+enforcement: machine
 ---
 
 # oklch-only

--- a/docs/rules/shade-tint-derive-only.md
+++ b/docs/rules/shade-tint-derive-only.md
@@ -2,6 +2,7 @@
 slug: shade-tint-derive-only
 stratum: language
 strictness: leaning
+enforcement: machine
 ---
 
 # shade-tint-derive-only

--- a/docs/rules/shade-tint-derive-only.md
+++ b/docs/rules/shade-tint-derive-only.md
@@ -1,0 +1,31 @@
+---
+slug: shade-tint-derive-only
+stratum: language
+strictness: leaning
+---
+
+# shade-tint-derive-only
+
+`shade`/`tint` are for deriving — mixing, scrim assembly, overlay floors — not for direct use as surface or ink colours.
+
+## Rationale
+
+The pairs are alpha ramps of pure black/white; used directly as fills or inks they bypass the scale anatomy and its contrast relationships. Reaching for them directly usually means a scale member is missing — which the deviation tally will reveal.
+
+## Examples
+
+### Incorrect
+
+```ts
+color: shade._700   // as a text colour
+```
+
+### Correct
+
+```ts
+backgroundColor: `color-mix(in oklch, ${surface.panel}, ${shade._500})`
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727).

--- a/docs/rules/shape-site-owned.md
+++ b/docs/rules/shape-site-owned.md
@@ -2,6 +2,7 @@
 slug: shape-site-owned
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # shape-site-owned

--- a/docs/rules/shape-site-owned.md
+++ b/docs/rules/shape-site-owned.md
@@ -1,0 +1,27 @@
+---
+slug: shape-site-owned
+stratum: language
+strictness: default
+---
+
+# shape-site-owned
+
+Geometry application is site-owned: which deformations an element carries, where, and at what aspect are design decisions at the site — never theme-global rules.
+
+## Rationale
+
+Geometry is composition, and composition is site-dependent — a large button may earn a top notch its smaller sibling doesn't; one panel family chamfers top-left, another bottom-right. A theme dictating "all corners rounded" or "all panels notched" makes every silhouette a reskin instead of a design. Themes own the *vocabulary* (the `depth` ramp, `profile` defaults are values); sites own the *application*. Recurring recipes become named presets, earned by recurrence.
+
+## Examples
+
+### Incorrect
+
+A theme token that forces a notch onto every container.
+
+### Correct
+
+A Card family choosing its own chamfer placement, with depths drawn from the ramp.
+
+## Evidence
+
+Recorded at founding (urban-ui-727), correcting an over-reach toward theme-owned profiles.

--- a/docs/rules/silhouette-bounding-box.md
+++ b/docs/rules/silhouette-bounding-box.md
@@ -1,0 +1,27 @@
+---
+slug: silhouette-bounding-box
+stratum: contract
+strictness: law
+---
+
+# silhouette-bounding-box
+
+A silhouette MUST NOT exceed its bounding box: every shape is the base rect minus deformations, never larger.
+
+## Rationale
+
+Because cuts never change an element's footprint, shape never disturbs spacing — the gap and inset scales hold under any theme's geometry. A perceived protrusion is uncut material left standing between two flanking cuts; the box still includes it. Glow bleeding past the silhouette is material, not geometry.
+
+## Examples
+
+### Incorrect
+
+An additive tab/lug drawn outside the element's box.
+
+### Correct
+
+Two flanking notches leaving a raised centre — the box is unchanged.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk geometry laws.

--- a/docs/rules/silhouette-bounding-box.md
+++ b/docs/rules/silhouette-bounding-box.md
@@ -2,6 +2,7 @@
 slug: silhouette-bounding-box
 stratum: contract
 strictness: law
+enforcement: machine
 ---
 
 # silhouette-bounding-box

--- a/docs/rules/square-baseline.md
+++ b/docs/rules/square-baseline.md
@@ -1,0 +1,29 @@
+---
+slug: square-baseline
+stratum: flagship
+strictness: law
+---
+
+# square-baseline
+
+The silhouette baseline is the square: chamfers and notches over rounding; edges are hard and mechanical.
+
+## Rationale
+
+The flagship's geometry identity — silhouettes grow from the square by machining straight cuts, never by softening. The `round` profile exists in the contract (other themes use it freely); under the flagship it is a sanctioned standing deviation only: avatars and round control thumbs.
+
+## Examples
+
+### Incorrect
+
+`profile: round` on a flagship panel corner.
+
+### Sanctioned deviation
+
+```
+// deviation(square-baseline): avatar — standing deviation, see register
+```
+
+## Evidence
+
+Recorded at founding (urban-ui-727); carried from poc-cyberpunk (radii-ban Law, re-scoped to the flagship stratum).

--- a/docs/rules/square-baseline.md
+++ b/docs/rules/square-baseline.md
@@ -2,6 +2,7 @@
 slug: square-baseline
 stratum: flagship
 strictness: law
+enforcement: machine
 ---
 
 # square-baseline

--- a/docs/rules/state-grammar.md
+++ b/docs/rules/state-grammar.md
@@ -7,11 +7,15 @@ enforcement: machine
 
 # state-grammar
 
-Interaction states are the exclusive gesture union `default | hover | press | disabled` plus the additive booleans `selected` and `focus`. The word `active` does not exist in the vocabulary.
+Interaction states are the exclusive gesture union `default | hover | press | disabled` plus the additive booleans `selected`, `invalid` and `focus`. Nav-current renders as `selected`. The word `active` does not exist in the vocabulary.
 
 ## Rationale
 
 `active` means "being pressed" in CSS and "current item" in navigation — one word, two meanings, and agents amplify ambiguity. `press` is unambiguous (and matches react-aria, so the behavioural layer and visual contract share words with zero translation). Selection is a persistent mode and focus an overlay — both demonstrably coexist with gestures (a selected tab is hovered; a pressed button is focused), so they compose rather than compete. Disabled sits in the union because it suppresses the other gestures, yet composes with selection (a disabled toggle holds its state).
+
+`invalid` is the same shape as `selected`: a persistent mode that composes with gestures and disabled, arriving on every form field via platform vocabulary (`aria-invalid`, react-aria's `isInvalid`). It styles from the `danger` scale — a sanctioned mapping, never a cross-scale borrow. Nav-current (`aria-current`) is the other half of the `active` collision, absorbed into `selected` rather than minted as a state.
+
+The boolean set is growable by test — a persistent mode, spanning component classes, composing with gestures. What fails it (an indeterminate checkbox glyph, a calendar's unavailable day, drag/drop visuals) is component-owned styling, not grammar.
 
 ## Examples
 
@@ -27,4 +31,4 @@ A selected+hovered tab rendering both contributions, each defined.
 
 ## Evidence
 
-Recorded at founding (urban-ui-727); `selected`-is-additive corrected during the interview (toggle-button case).
+Recorded at founding (urban-ui-727); `selected`-is-additive corrected during the interview (toggle-button case). `invalid` added, nav-current folded into `selected`, and the growth test written during the PR 50 review against the react-aria catalogue — every form field ships `isInvalid`, so omitting it would have made the first form tranche a deviation farm.

--- a/docs/rules/state-grammar.md
+++ b/docs/rules/state-grammar.md
@@ -1,0 +1,29 @@
+---
+slug: state-grammar
+stratum: language
+strictness: law
+---
+
+# state-grammar
+
+Interaction states are the exclusive gesture union `default | hover | press | disabled` plus the additive booleans `selected` and `focus`. The word `active` does not exist in the vocabulary.
+
+## Rationale
+
+`active` means "being pressed" in CSS and "current item" in navigation — one word, two meanings, and agents amplify ambiguity. `press` is unambiguous (and matches react-aria, so the behavioural layer and visual contract share words with zero translation). Selection is a persistent mode and focus an overlay — both demonstrably coexist with gestures (a selected tab is hovered; a pressed button is focused), so they compose rather than compete. Disabled sits in the union because it suppresses the other gestures, yet composes with selection (a disabled toggle holds its state).
+
+## Examples
+
+### Incorrect
+
+```ts
+'.active': { … }          // pressed? current? unknowable
+```
+
+### Correct
+
+A selected+hovered tab rendering both contributions, each defined.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); `selected`-is-additive corrected during the interview (toggle-button case).

--- a/docs/rules/state-grammar.md
+++ b/docs/rules/state-grammar.md
@@ -2,6 +2,7 @@
 slug: state-grammar
 stratum: language
 strictness: law
+enforcement: machine
 ---
 
 # state-grammar

--- a/docs/rules/structural-focus.md
+++ b/docs/rules/structural-focus.md
@@ -2,6 +2,7 @@
 slug: structural-focus
 stratum: language
 strictness: law
+enforcement: review
 ---
 
 # structural-focus

--- a/docs/rules/structural-focus.md
+++ b/docs/rules/structural-focus.md
@@ -1,0 +1,27 @@
+---
+slug: structural-focus
+stratum: language
+strictness: law
+---
+
+# structural-focus
+
+Focus is indicated structurally — a ring drawn from `static.focus` with `focus-visible` semantics. Emission or colour shifts never substitute.
+
+## Rationale
+
+Keyboard-first desktop archetype plus react-aria makes focus a first-class rendered state with a legal floor (visible focus is an AA requirement). On an emissive surface, "more glow" is indistinguishable from hover — the failure [[flair-never-sole-carrier]] exists to prevent. One app-wide focus colour keeps the indicator recognisable across every scale and material.
+
+## Examples
+
+### Incorrect
+
+Focus expressed as emission level `hot`.
+
+### Correct
+
+A `static.focus` ring, optionally garnished with glow.
+
+## Evidence
+
+Session-1 Decision 6 ([[product-framing]]); mechanised in urban-ui-727. Ring width/offset tokens tracked in urban-ui-6yb.

--- a/docs/rules/text-balance.md
+++ b/docs/rules/text-balance.md
@@ -1,0 +1,27 @@
+---
+slug: text-balance
+stratum: language
+strictness: default
+---
+
+# text-balance
+
+Classify text by what it balances against: its environment → UI scale; itself → editorial scale.
+
+## Rationale
+
+UI text is an element among elements — it sizes against neighbouring controls and panels, favouring density. Editorial text is a self-contained reading experience — body-anchored, internally rhythmic, generous. Single-scale systems fail exactly here: editorial headers need far more differentiation from body than panel headings need from labels. The test settles boundary cases mechanically: an error message balances against its field → UI; long-form you actually read → editorial.
+
+## Examples
+
+### Incorrect
+
+Rendering a settings description with `editorial.body`.
+
+### Correct
+
+Error messages, field descriptions, tooltips → UI scale; a changelog entry → editorial.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); the two-scale decision.

--- a/docs/rules/text-balance.md
+++ b/docs/rules/text-balance.md
@@ -2,6 +2,7 @@
 slug: text-balance
 stratum: language
 strictness: default
+enforcement: review
 ---
 
 # text-balance

--- a/docs/rules/tokens-are-spec.md
+++ b/docs/rules/tokens-are-spec.md
@@ -1,0 +1,27 @@
+---
+slug: tokens-are-spec
+stratum: contract
+strictness: law
+---
+
+# tokens-are-spec
+
+Tokens are implementation-independent: the contract is a specification; CSS custom properties, JS values, or documented conventions are carriers.
+
+## Rationale
+
+Previous iterations died with their styling technology (stitches, vanilla-extract). The schema must outlive any carrier — StyleX is one implementation of the system, not the system. Some contract members (e.g. the `profile` vocabulary) may never be CSS values at all.
+
+## Examples
+
+### Incorrect
+
+Designing a token that only makes sense as a StyleX var (e.g. encoding behaviour in a carrier-specific hack).
+
+### Correct
+
+Defining `profile: square · straight · round` as a vocabulary, carried today by the shape generator's API.
+
+## Evidence
+
+Recorded at founding (urban-ui-727); dependency-churn scar tissue in [[product-framing]].

--- a/docs/rules/tokens-are-spec.md
+++ b/docs/rules/tokens-are-spec.md
@@ -2,6 +2,7 @@
 slug: tokens-are-spec
 stratum: contract
 strictness: law
+enforcement: judgment
 ---
 
 # tokens-are-spec


### PR DESCRIPTION
## Summary

Captures the full design-language groundwork from the urban-ui-727 gorilla sessions: what we're building (product framing), the token architecture (theme contract + guidelines), and a per-file rule register with a skill to grow it. Includes ADR-0008 (global CSS distribution).

## Changes

- `docs/knowledge/product-framing.md` — the needle + 11 standing decisions from the use-case session (audience, 4X/RTS archetype, coherence model, agents-first, a11y floor, proving ground, scope, themes, platform)
- `docs/knowledge/theme-guidelines.md` — the reasoning: coherence-group machinery, var/group/category/theme tiers, flagship-as-defaults, scheme-as-facet, per-domain decisions (colour, materials, shape, text, space, layers)
- `docs/knowledge/theme-contract.md` — the normative inventory: vocabularies, groups, members, cross-scale categories, open slots (dense/scannable)
- `docs/knowledge/design-language.md` — three strata (contract/language/flagship), the deviation model (`// deviation(<slug>): <reason>`), watches
- `docs/rules/` — 28 seed rules, one file per rule (slug/stratum/strictness, rationale, incorrect/correct examples, evidence), indexed in `docs/rules.md`
- `.claude/skills/rule/` — skill to record rules while hot, matching the format
- `docs/adr/0008-global-css-distribution.md` — one static `global.css` from `@urban-ui/theme` (`reset` + `base` cascade layers below StyleX); amends ADR-0005's no-CSS letter
- Beads: urban-ui-btl (Layers) resolved in-session; urban-ui-6yb (component sizing), urban-ui-ed9 (motion), urban-ui-s2e (materials lab) filed as deferred; urban-ui-gmn filed for human re-review of these docs in a fresh session

## Testing

Docs only — no runtime surface. Wiki-links resolve through the docs/ indexes (adr.md, knowledge.md, rules.md).

Refs: urban-ui-727

🤖 Generated with [Claude Code](https://claude.com/claude-code)