### PR TITLE
:books: Surface the design-rule register to agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,5 @@ _Add a brief overview of your project architecture_
 ## Conventions & Patterns
 
 Repo-wide conventions live in [docs/knowledge/conventions.md](docs/knowledge/conventions.md) — read it before structuring new code or packages.
+
+Design-language rules live in [docs/rules.md](docs/rules.md) — read the register before writing or reviewing UI, component, or theme code. Deviations are cited in place: `// deviation(<slug>): <reason>`.

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -9,3 +9,4 @@ Repo-wide conventions that don't belong to any single package or record. Flat li
 - **Categorise by intent, not by kind.** No utility buckets (`utils/`, `helpers/`, `tooling/`) — a module or package is named for the question it answers (`internal/workspace`: "what packages exist here?"), never for the shape of the code inside it.
 - **Prefer single-arity functions.** A function that needs more than one value takes a single object with named fields, not a parameter list.
 - **Colocate tests with implementation.** `src/thing.test.ts` sits beside `src/thing.ts` — no separate `test/` trees for test files (fixture directories may still stand alone).
+- **UI work obeys the rule register.** Component, styling, and theme changes follow [[rules]]; deviations are cited in place as `// deviation(<slug>): <reason>`.


### PR DESCRIPTION

## Summary
PR #50 landed the design-language rule register, but agents had no routing signal telling them *when* to read it — `docs/rules.md` was just one of four index links. This adds trigger markers in the two discovery paths agents follow.

## Changes
- `AGENTS.md` (and `CLAUDE.md` via the symlink): new paragraph under **Conventions & Patterns** — read `docs/rules.md` before writing or reviewing UI, component, or theme code; cite deviations in place as `// deviation(<slug>): <reason>`. Parallels the existing conventions marker, which carries a when-to-read trigger rather than a bare link.
- `docs/knowledge/conventions.md`: new flat-list entry **"UI work obeys the rule register."**, wiki-linked to `[[rules]]` — the durable convention itself, catching agents routed to conventions without the AGENTS.md context.

## Testing
Docs only — no runtime surface. Verify the links resolve and the conventions entry matches the file's one-rule-per-entry format.